### PR TITLE
Cleanup README and variable naming

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -4,20 +4,21 @@ MAX_CONCURRENT_LLMS=10
 MAX_CONCURRENT_DOCLING=16
 
 # Model endpoints
-# LLM_* controls text generation. EMBEDDING_* controls semantic search.
+# LLM_* controls text generation. VLM_* controls image/chart descriptions.
+# EMBEDDING_* controls semantic search.
 # Leave *_API_KEY blank for local Ollama or providers that use their own env vars.
 LLM_MODEL="ollama/qwen3:8b"
 LLM_BASE_URL=http://localhost:11434
 LLM_API_KEY=
+
+VLM_MODEL="ollama/qwen3-vl:8b"
+VLM_BASE_URL=http://localhost:11434
+VLM_API_KEY=
+
 EMBEDDING_MODEL="ollama/qwen3-embedding:8b"
 EMBEDDING_BASE_URL=http://localhost:11434
 EMBEDDING_API_KEY=
 
-# Backward-compatible aliases. New installs should use LLM_MODEL and
-# EMBEDDING_MODEL; these remain supported for existing .env files.
-DEFAULT_LLM=
-DEFAULT_VLM="ollama/qwen3-vl:8b"
-DEFAULT_EMBEDDINGS=
 OLLAMA_NUM_CTX_MAX=262144
 OLLAMA_NUM_CTX=32768
 OLLAMA_NUM_PARALLEL=16
@@ -35,18 +36,18 @@ OLLAMA_HOST=http://localhost:11434
 # STORAGE_PROVIDER: "local", "google", or "hybrid"
 #   local  — read/write against a local directory only.
 #   google — read/write directly against Google Drive.
-#   hybrid — read/write against a local mirror dir; reads fall back to Drive
+#   hybrid — read/write against a local mirror path; reads fall back to Drive
 #            (and cache to mirror) on miss; Markdown writes also upload to Drive
 #            as Google Docs. cache/ stays local-only.
 STORAGE_PROVIDER="local"
 
-# If local:  An absolute directory path (e.g., /Users/claw-agent/temp/)
+# If local:  An absolute path (e.g., /Users/claw-agent/temp/)
 # If google/hybrid: A Google Drive Folder ID, "root", or a folder path/name
 # such as "SICTIC-AI" or "SICTIC-AI/prod".
 STORAGE_PATH=
 
-# If hybrid: absolute path to the local mirror directory (working copy).
-STORAGE_MIRROR_DIR=
+# If hybrid: absolute path to the local mirror path (working copy).
+STORAGE_MIRROR_PATH=
 
 # (Optional) Google Drive Credentials
 # Defaults to ~/.openclaw/gdrive-ops-credentials.json if empty
@@ -58,6 +59,6 @@ GEMINI_API_KEY=
 APIFY_KEY=
 DEALUM_API_KEY=
 
-#LOCAL DIRECTORIES
-REPO_DIR=
-WORKSPACE_DIR=
+#LOCAL PATHS
+REPO_PATH=
+WORKSPACE_PATH=

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ __pycache__/
 .pytest-storage/
 .storage/
 .storage-mirror/
+gdrive-mirror/
 
 venv/
 logs/

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 ![License MIT](https://img.shields.io/badge/license-MIT-green.svg)
 ![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)
 
-Welcome to the SICTIC-AI toolkit! This is an open-source collection of AI-powered analysis routines (AKA skills) designed to supercharge the startup ecosystem. It is completely free to use and easy to contribute to! 
+Welcome to the SICTIC-AI toolkit! This is an open-source collection of AI-powered analysis routines (AKA skills) designed to supercharge the startup ecosystem. It is completely free to use and easy to contribute to!
 
 This toolkit serves four audiences:
-* **Startups:** Prepare for your first funding round by running our AI over your data room for a dry run.
+* **Startups:** Prepare for your first funding round with a dry run of our AI on your data room.
 * **Business Angels:** Automate common assessments in your Due Diligence process.
 * **BA Clubs (like SICTIC):** Automate member engagement, startup selection, DD, and monitoring past transactions.
 * **AI Wizards:** Co-develop and refine the future of early stage funding rounds with us!
@@ -16,18 +16,18 @@ This toolkit serves four audiences:
 
 | Category | Skill | Status | Description |
 |---|---|---|---|
-| **Community** | `expert_search` | ✅ | Identifies club members with relevant domain expertise to assist with due diligence or operational support |
-| | `potential_investors` | ✅ | Identifies potential investors for a startup |
+| **Community** | `expert_search` | ✅ | Identifies eight club members with the most relevant domain expertise to assist with due diligence or operational support |
+| | `potential_investors` | ✅ | Identifies sixteen potential investors for a startup with the best match |
 | | `advocates` | ✅ | Identifies inspiring members to represent the organization at external events |
 | | `investment_appetite` | ✅ | Articulates and maps the specific investment sweet spot and thesis for each member |
-| | `suggested_startups` | ✅ |  Proposes 5–7 attractive startups in active fundraising to each members |
-| **Startup Selection & Jury** | `submission_ready` | | Basic check to verify if a startup's application and submitted materials are complete |
+| | `suggested_startups` | ✅ | Proposes 5–7 attractive startups in active fundraising to each of our 500+ members |
+| **Startup Selection & Jury** | `submission_ready` | | Basic checks to verify if a startup's application and submitted materials are complete |
 | | `pitch_ready` | | Evaluates the clarity and completeness of the startup's materials and value proposition for investor pitch sessions |
 | **Due Diligence** | `startup_profile` | ✅ | Generates a succinct overview of the startup. Serves as input for many other skills |
 | | `team_profile` | ✅ | Provides a balanced assessment of individual founders and the complete team dynamics |
 | | `person_profile` | ✅ | Generates a comprehensive profile for any person in a dataset (either a founder or a club member) |
 | | `startup_traction` | ✅ | Summarizes and provides a quantified overview of the startup's market traction |
-| | `dd_checks` | ✅ | Executes a comprehensive suite of 100+ due diligence checks on a startup |
+| | `dd_checks` | ✅ | Executes a comprehensive suite of 100+ common due diligence checks on a startup |
 | | `market_review` | | Analyzes the target market, customer needs, competitive landscape, and potential substitutes |
 | | `t&c_review` | | Reviews and assesses the terms and conditions of the proposed funding round |
 | **Ongoing Monitoring** | `alerts&news` | | Monitors and interprets relevant news and updates concerning portfolio startups |
@@ -35,17 +35,32 @@ This toolkit serves four audiences:
 | | `portfolio_mgmt` | | Generates risk-return overviews and performance metrics for a portfolio of startups |
 
 
+<details>
+<summary>▶ Click to see a sample Startup Profile output for SpaceX</summary>
+
+```markdown
+# Startup Profile: SpaceX
+
+1. **Oneliner:** Design, manufacture, and launch of advanced rockets and spacecraft.
+2. **Core industry:** Aerospace Manufacturing and Space Transportation Services.
+3. **Technology:** Highly verticalized manufacturing of reusable launch vehicles (Falcon 9, Starship); significant reliance on complex materials science, extreme-environment engineering, and proprietary autonomous landing software. Technical single point of failure lies in the unproven orbital refueling and heat shield viability of the Starship platform.
+4. **Business model:** B2B/B2G payload launch services (commercial satellites, NASA/DoD contracts) and B2C direct-to-consumer satellite internet (Starlink). Structural risks include astronomical capital expenditure requirements, reliance on favorable government regulatory environments, and the inherent binary risk of catastrophic mission failures destroying hardware and client payloads.
+5. **Current challenges:** Scaling Starship production to achieve promised launch cadence and cost-reduction; navigating intense FAA environmental and launch licensing scrutiny; proving the economic viability of the Starlink constellation against hardware degradation timelines. Expert due diligence required on Starship payload capacities and orbital refueling logistics.
+```
+</details>
+
+
 ## Contributing
 
 The setup is deliberately simple so everyone can join and co-develop:
 * This is about investing expertise and insight, not IT know-how.
-* You can safely create new skills or edit existing ones directly inside your UI. 
-* Then your AI agent will do the syncing to github for you; it has a  `sictic_git_sync` skill. This skill also acts as an architectural gatekeeper—reviewing your code, enforcing the simplicity standards
+* You can safely create new skills or edit existing ones directly inside your UI.
+* Then your AI agent will do the syncing to GitHub for you; it has a `sictic_git_sync` skill. This skill also acts as an architectural gatekeeper, reviewing your code and enforcing the simplicity standards.
 
 ## Runtime Context
 
-The toolkit requires a Unix environment (**macOS, Linux, or WSL2**) and an AI Agent 
-(like **OpenClaw, Claude Code, or Gemini Spark**) to converse with the skills. 
+The toolkit requires a Unix environment (**macOS, Linux, or WSL2**) and an AI Agent
+(like **OpenClaw, Claude Code, Codex, or Gemini Spark**) to converse with the skills.
 We primarily develop using macOS and OpenClaw, but the architecture is OS-agnostic.
 
 ## Quickstart Setup
@@ -71,8 +86,8 @@ bash Miniforge3-*.sh  # Follow the prompts, say 'yes' to init
 exec $SHELL           # reload your terminal
 ```
 
-Install **Ollama** when using local `ollama/...` models. Local models are the
-default in `.env-template` and are useful for heavy document parsing.
+Install **Ollama** if you want to use local `ollama/...` models. Local models
+are our default in `.env-template` and are useful for heavy document parsing.
 * **macOS:** `brew install ollama`
 * **Linux/WSL2:** `curl -fsSL https://ollama.com/install.sh | sh`
 
@@ -89,16 +104,14 @@ commands execute the current repo code while the target directory contains
 portable `SKILL.md` instructions for your agent.
 
 ```bash
-# macOS example
+# Same for macOS, Linux, and WSL2
 ./install_skills_conda.sh --target /Users/you/.openclaw/workspace-ops/skills
-
-# Linux / WSL2 example
-./install_skills_conda.sh --target "$HOME/.openclaw/workspace-ops/skills"
 ```
 
-The installer creates the same `sictic-env` on macOS and Linux. Docling uses
-Apple Vision OCR through `ocrmac` on macOS and RapidOCR on Linux; both paths use
-the same `skills.dataset_chat` ingestion code.
+The installer creates the conda environment `sictic-env` for macOS, Linux, and
+WSL2. `skills.dataset_chat` uses Docling for document ingestion, with:
+* Apple Vision OCR through `ocrmac` on macOS.
+* RapidOCR on Linux/WSL2.
 
 ### Step 3: Configuration
 
@@ -108,28 +121,30 @@ configure these variables:
 
 | \# | Variable | Purpose | Example |
 |---|---|---|---|
-|1| `WORKSPACE_DIR` | Absolute path to the AI workspace skills directory | `/Users/you/.openclaw/workspace-ops/skills` |
-|2| `REPO_DIR` | Absolute path to the root of this SICTIC-AI git repository | `/Users/you/SICTIC-AI` |
-|3| `STORAGE_PROVIDER` | Where should data be saved? (`local` or `google`) | `local` |
+|1| `WORKSPACE_PATH` | Absolute path to the AI workspace skills directory | `/Users/you/.openclaw/workspace-ops/skills` |
+|2| `REPO_PATH` | Absolute path to the root of this SICTIC-AI git repository | `/Users/you/SICTIC-AI` |
+|3| `STORAGE_PROVIDER` | Where should data be saved? (`local`, `google`, or `hybrid`) | `local` |
 |4| `STORAGE_PATH` | If `local`: absolute path. If `google`/`hybrid`: Drive folder ID, `root`, or folder path/name | `/Users/you/sictic_data`, `SICTIC-AI`, or `root` |
-|5| `LLM_MODEL` | The primary text-generation model used for analysis | `google/gemini-flash-latest` or `ollama/qwen3:8b` |
-|6| `LLM_BASE_URL` | Base URL for the text-generation endpoint; blank uses the provider default | `http://localhost:11434` |
-|7| `LLM_API_KEY` | API key for the text-generation endpoint when needed | blank for local Ollama |
-|8| `EMBEDDING_MODEL` | The model used for semantic search embeddings | `ollama/qwen3-embedding:8b` or `openai/text-embedding-3-small` |
-|9| `EMBEDDING_BASE_URL` | Base URL for the embedding endpoint; blank uses the provider default | `http://localhost:11434` |
-|10| `EMBEDDING_API_KEY` | API key for the embedding endpoint when needed | blank for local Ollama |
-|11| `DEFAULT_VLM` | The model used for extracting text from images/charts | `ollama/qwen3-vl:8b` or `openai/gpt-4o-mini` |
-|12| `RANKED_LLMS` | If insights md files were created with several models, the preferred ranking for re-use. (CSV list) | see `.env-template` |
+|5| `STORAGE_MIRROR_PATH` | If `hybrid`: absolute path to the local Google Drive mirror | `/Users/you/SICTIC-AI/gdrive-mirror` |
+|6| `LLM_MODEL` | The primary text-generation model used for analysis | `google/gemini-flash-latest` or `ollama/qwen3:8b` |
+|7| `LLM_BASE_URL` | Base URL for the text-generation endpoint; blank uses the provider default | `http://localhost:11434` |
+|8| `LLM_API_KEY` | API key for the text-generation endpoint when needed | blank for local Ollama |
+|9| `VLM_MODEL` | The model used for extracting text from images/charts | `ollama/qwen3-vl:8b` or `openai/gpt-4o-mini` |
+|10| `VLM_BASE_URL` | Base URL for the vision-language endpoint; defaults to `LLM_BASE_URL` | `http://localhost:11434` |
+|11| `VLM_API_KEY` | API key for the vision-language endpoint; defaults to `LLM_API_KEY` | blank for local Ollama |
+|12| `EMBEDDING_MODEL` | The model used for semantic search embeddings | `ollama/qwen3-embedding:8b` or `openai/text-embedding-3-small` |
+|13| `EMBEDDING_BASE_URL` | Base URL for the embedding endpoint; blank uses the provider default | `http://localhost:11434` |
+|14| `EMBEDDING_API_KEY` | API key for the embedding endpoint when needed | blank for local Ollama |
+|15| `RANKED_LLMS` | If insights md files were created with several models, the preferred ranking for re-use. (CSV list) | see `.env-template` |
 
 *(Note: The other variables in `.env-template` are explained inline. You don't need to change them).*
-`DEFAULT_LLM` and `DEFAULT_EMBEDDINGS` are still accepted as compatibility aliases, but new installs should configure `LLM_*` and `EMBEDDING_*`.
 
 ### Step 4: Start Background Services
 
 SICTIC-AI relies on Qdrant for semantic search and on Ollama when any configured
 model starts with `ollama/`. The launcher downloads Qdrant when needed, starts
 Qdrant and Ollama, and pulls the Ollama models referenced by `LLM_MODEL`,
-`EMBEDDING_MODEL`, and `DEFAULT_VLM` if they are not already available.
+`EMBEDDING_MODEL`, and `VLM_MODEL` if they are not already available.
 
 ```bash
 ./launch.sh start
@@ -137,14 +152,14 @@ Qdrant and Ollama, and pulls the Ollama models referenced by `LLM_MODEL`,
 ./launch.sh stop    # shut down local background services
 ```
 
-### Step 5: Run a Skill
+### Step 5: Run a Skill in the harness
 
-You are ready to go. Execute user-facing skills through the lightweight
-slash-command harness:
+You are ready to go. Execute user-facing skills either through the lightweight
+slash-command harness or directly:
 
 ```bash
 conda run -n sictic-env python -m skills.harness /startup_profile SpaceX
-conda run -n sictic-env python -m skills.harness /dataset_chat SpaceX "What are the main risks?"
+conda run -n sictic-env python -m skills.dataset_chat SpaceX "What are the main risks?"
 ```
 
 For interactive manual testing, start the harness without a slash command:
@@ -155,110 +170,60 @@ conda run -n sictic-env python -m skills.harness
 
 Inside the harness, run `/help` to list commands such as `/dataset_chat <dataset> <question>`, `/startup_profile <startup>`, and `/dd_checks <startup>`.
 
-### Member Profile Indexing Scripts
+### Using it in practice
 
-Community matching skills such as `expert_search`, `potential_investors`, and
-`advocates` search the derived `sictic-members-person-profile` dataset. They do
-not scan every Google Drive insight on demand. Use the two maintenance scripts
-below to create member profile insights and then hydrate the derived dataset
-from those insights.
+#### 1. Community management
 
-#### 1. Hydrate existing profile insights into a derived dataset
+Communities can be large, so it is useful to do some preparation overnight.
+
+To make an inventory of all persons mentioned in `community/sictic-members/datasets/`, run:
 
 ```bash
-conda run -n sictic-env python -m lib.dataset_from_insight --insight-name person_profile --source-dataset sictic-members --dry-run
+conda run -n sictic-env python -m person_profile.persons_in_dataset --dataset sictic.members
+```
+
+It will generate a draft of all members in `community/sictic-members/insights/persons-in-dataset-sictic-members-manual.md`. Probably it is quite incomplete and you want to edit it manually. From there on, the system will use that list of members.
+
+Next you want to create a comprehensive profile of each member combining their LinkedIn profile, their resumes and other credentials. For this you use:
+
+```bash
+conda run -n sictic-env python -m person_profile --dataset sictic.members
+```
+
+The resulting profiles are in:
+
+```text
+storage/community/sictic-members/insights/person-profile/
+```
+
+It may complain that it cannot fetch LinkedIn profiles. From `lib/adapters/linkedin.py`, you can use:
+* `linkedin_missing_profiles` to get a list of missing LinkedIn profiles.
+* `linkedin_bulk_upload` to upload a JSON with those profiles into the system. It knows which dataset each profile belongs to.
+
+The matching skills such as `expert_search`, `potential_investors`, and
+`advocates` search a derived `sictic-members-person-profile` dataset for the best fit. They do not scan every Google Drive insight on demand. Use the maintenance script below to create member profile insights and then hydrate the derived dataset from those insights.
+
+```bash
 conda run -n sictic-env python -m lib.dataset_from_insight --insight-name person_profile --source-dataset sictic-members
 ```
 
-This command expects existing profile insight Markdown under:
+#### 2. Overnight Refresh
 
-```text
-storage/community/sictic-members/insights/person-profile/
-```
-
-It then:
-* scans the existing `person_profile` insight files;
-* groups alternative files by person;
-* chooses the preferred profile for each person using `RANKED_LLMS`;
-* writes the selected files into `storage/community/sictic-members-person-profile/datasets/`;
-* removes stale derived files when a different LLM output is now preferred.
-
-Use `--dry-run` first. A dry run showing zero candidates means there are no
-matching profile insight files at the configured storage path yet, or the local
-hybrid mirror has not hydrated them.
-
-#### 2. Generate member profiles from source member data
+The `bulk_refresh` command can refresh a set of insights on a set of datasets.
+* If the datasets are not specified, it will refresh all skills with a `__active_dataset__` file in the dataset subfolder.
+* If the insights are not specified, it will refresh all relevant skills.
 
 ```bash
-conda run -n sictic-env python scripts/generate_member_profiles.py --limit 10
+# refresh the person_profile on spaceX
+conda run -n sictic-env python -m bulk_refresh/ --insight-name "person_profile" --dataset spaceX
+# refresh all insights on spacex
+conda run -n sictic-env python -m bulk_refresh/ --dataset spacex
+# refresh all the person_profile for all active dataset
+conda run -n sictic-env python -m bulk_refresh/ --insight-name "person_profile"
+# refresh all insights on all active dataset
+conda run -n sictic-env python -m bulk_refresh/
+
 ```
-
-This script reads members from the configured community dataset:
-
-```text
-storage/community/sictic-members/datasets/
-```
-
-The default mode is intentionally lightweight. It uses cached LinkedIn member
-JSON files and generates `person_profile` insights without first indexing the
-entire member source dataset. This is the right mode for quick tests and for
-building the first batch of reusable member insights.
-
-Useful options:
-
-```bash
-# Generate only selected people
-conda run -n sictic-env python scripts/generate_member_profiles.py --names "Urs Gubser,Jane Doe"
-
-# Generate insight files but do not hydrate storage/community/sictic-members-person-profile/datasets yet
-conda run -n sictic-env python scripts/generate_member_profiles.py --limit 10 --skip-index
-
-# Remove existing selected outputs before regenerating
-conda run -n sictic-env python scripts/generate_member_profiles.py --limit 10 --force-refresh
-```
-
-For richer profiles that include semantic context from the broader member
-dataset, run the heavy mode explicitly:
-
-```bash
-conda run -n sictic-env python scripts/generate_member_profiles.py --limit 10 --with-dataset-context --sync-source
-```
-
-This can take a long time the first time because `--sync-source` parses and
-embeds the full `sictic-members` dataset into Qdrant before the ten profile
-generations begin. Subsequent runs are faster once Qdrant and the parsed
-Markdown storage is current.
-
-The generated profiles are written to:
-
-```text
-storage/community/sictic-members/insights/person-profile/
-```
-
-Unless `--skip-index` is used, the script then calls
-`dataset_from_insight` so the selected profiles end up in:
-
-```text
-storage/community/sictic-members-person-profile/datasets/
-```
-
-The next `dataset_chat` call against `sictic-members-person-profile` will sync/index as needed.
-
-<details>
-<summary>▶ Click to see a sample Startup Profile output for SpaceX</summary>
-
-```markdown
-# Startup Profile: SpaceX
-
-1. **Oneliner:** Design, manufacture, and launch of advanced rockets and spacecraft.
-2. **Core industry:** Aerospace Manufacturing and Space Transportation Services.
-3. **Technology:** Highly verticalized manufacturing of reusable launch vehicles (Falcon 9, Starship); significant reliance on complex materials science, extreme-environment engineering, and proprietary autonomous landing software. Technical single point of failure lies in the unproven orbital refueling and heat shield viability of the Starship platform.
-4. **Business model:** B2B/B2G payload launch services (commercial satellites, NASA/DoD contracts) and B2C direct-to-consumer satellite internet (Starlink). Structural risks include astronomical capital expenditure requirements, reliance on favorable government regulatory environments, and the inherent binary risk of catastrophic mission failures destroying hardware and client payloads.
-5. **Current challenges:** Scaling Starship production to achieve promised launch cadence and cost-reduction; navigating intense FAA environmental and launch licensing scrutiny; proving the economic viability of the Starlink constellation against hardware degradation timelines. Expert due diligence required on Starship payload capacities and orbital refueling logistics.
-```
-</details>
-
----
 
 ## Where is my data?
 
@@ -279,7 +244,7 @@ to `storage/startups/spacex/insights/`.
 
 Document parsing is handled locally by Docling. On macOS, the installer includes
 the `ocrmac` extra for Apple Vision OCR. On Linux/WSL2, the installer uses the
-standard Docling package and RapidOCR. In both cases, `DEFAULT_VLM` is used for
+standard Docling package and RapidOCR. In both cases, `VLM_MODEL` is used for
 image and chart descriptions through Ollama or another configured model provider.
 
 ## Google Drive Integration (Production Mode)
@@ -297,10 +262,10 @@ For local testing with Google credentials, prefer `STORAGE_PROVIDER="hybrid"`. I
 Required `.env` fields for hybrid testing:
 
 ```bash
-REPO_DIR=/absolute/path/to/SICTIC-AI
+REPO_PATH=/absolute/path/to/SICTIC-AI
 STORAGE_PROVIDER=hybrid
 STORAGE_PATH=<google-drive-folder-id-root-or-folder-path>
-STORAGE_MIRROR_DIR=/absolute/path/to/local-mirror
+STORAGE_MIRROR_PATH=/absolute/path/to/local-mirror
 GDRIVE_CREDENTIALS=/absolute/path/to/credentials.json
 GDRIVE_TOKEN=/absolute/path/to/token.json
 QDRANT_HOST=http://localhost:6333
@@ -308,7 +273,9 @@ OLLAMA_HOST=http://localhost:11434
 LLM_MODEL=...
 LLM_BASE_URL=...
 LLM_API_KEY=...
-DEFAULT_VLM=...
+VLM_MODEL=...
+VLM_BASE_URL=...
+VLM_API_KEY=...
 EMBEDDING_MODEL=...
 EMBEDDING_BASE_URL=...
 EMBEDDING_API_KEY=...

--- a/README.md
+++ b/README.md
@@ -170,9 +170,9 @@ conda run -n sictic-env python -m skills.harness
 
 Inside the harness, run `/help` to list commands such as `/dataset_chat <dataset> <question>`, `/startup_profile <startup>`, and `/dd_checks <startup>`.
 
-### Using it in practice
+## Using it in practice
 
-#### 1. Community management
+### 1. Community management
 
 Communities can be large, so it is useful to do some preparation overnight.
 
@@ -207,7 +207,7 @@ The matching skills such as `expert_search`, `potential_investors`, and
 conda run -n sictic-env python -m lib.dataset_from_insight --insight-name person_profile --source-dataset sictic-members
 ```
 
-#### 2. Overnight Refresh
+### 2. Overnight Refresh
 
 The `bulk_refresh` command can refresh a set of insights on a set of datasets.
 * If the datasets are not specified, it will refresh all skills with a `__active_dataset__` file in the dataset subfolder.
@@ -225,7 +225,7 @@ conda run -n sictic-env python -m bulk_refresh/
 
 ```
 
-## Where is my data?
+### 3. Where is my data?
 
 Once configured, the system uses the storage domains defined in
 `config/storage_domains.json`. The default layout is:
@@ -247,15 +247,15 @@ the `ocrmac` extra for Apple Vision OCR. On Linux/WSL2, the installer uses the
 standard Docling package and RapidOCR. In both cases, `VLM_MODEL` is used for
 image and chart descriptions through Ollama or another configured model provider.
 
-## Google Drive Integration (Production Mode)
+### 4. Google Drive Integration (Production Mode)
 
-By default (`STORAGE_PROVIDER="local"`), all datasets and generated insights are written to the local file system path provided in `STORAGE_PATH`.
+(You read this far, so you're serious about this.) By default (`STORAGE_PROVIDER="local"`), all datasets and generated insights are written to the local file system path provided in `STORAGE_PATH`.
 
 In production at SICTIC, we use Google Drive to share datasets and insights with Deal Leads. When `STORAGE_PROVIDER="google"`, the skills read and write directly to Google Drive via the native API.
 
 **Setting up the Google Drive API requires creating an OAuth Desktop-App client in the Google Cloud Console.** Because this process involves navigating complex Google Cloud settings and handling JSON credentials, the best approach is to ask your AI assistant to walk you through the Google Cloud setup and authenticate the credentials for you (We did it with Openclaw)
 
-## Local Google-backed Testing
+#### Local Google-backed Testing
 
 For local testing with Google credentials, prefer `STORAGE_PROVIDER="hybrid"`. In hybrid mode, Google Drive is used as a read fallback while generated files are written to a local mirror first. Markdown outputs outside local cache paths are then uploaded to Drive as Google Docs; updating an existing Google Doc preserves the file ID and creates a normal Drive revision.
 

--- a/install_skills_conda.sh
+++ b/install_skills_conda.sh
@@ -295,16 +295,6 @@ env_set() {
     mv "$tmp" "$ENV_PATH"
 }
 
-env_first() {
-    for key in "$@"; do
-        value=$(env_get "$key" || true)
-        if [ -n "$value" ]; then
-            printf '%s\n' "$value"
-            return
-        fi
-    done
-}
-
 ask_env() {
     key="$1"
     prompt="$2"
@@ -355,8 +345,8 @@ if [ "$INTERACTIVE" -eq 1 ]; then
     echo "Press Enter to keep the value shown in brackets. Secrets are preserved when already configured."
     echo
 
-    ask_env "REPO_DIR" "Repository directory" "$REPO_ROOT" 1 0
-    ask_env "WORKSPACE_DIR" "Installed skills directory" "$TARGET" 1 0
+    ask_env "REPO_PATH" "Repository path" "$REPO_ROOT" 1 0
+    ask_env "WORKSPACE_PATH" "Installed skills path" "$TARGET" 1 0
     while :; do
         ask_env "STORAGE_PROVIDER" "Storage provider (local, google, hybrid)" "$(env_get STORAGE_PROVIDER || true)" 1 0
         storage_provider=$(env_get STORAGE_PROVIDER || true)
@@ -368,27 +358,34 @@ if [ "$INTERACTIVE" -eq 1 ]; then
 
     if [ "$storage_provider" = "local" ]; then
         ask_env "STORAGE_PATH" "Local storage path" "$REPO_ROOT/.storage" 1 0
-        ask_env "STORAGE_MIRROR_DIR" "Storage mirror dir (blank for local mode)" "" 0 0
+        ask_env "STORAGE_MIRROR_PATH" "Storage mirror path (blank for local mode)" "" 0 0
     elif [ "$storage_provider" = "google" ]; then
         ask_env "STORAGE_PATH" "Google Drive folder ID, root, or folder path/name" "" 1 0
-        ask_env "STORAGE_MIRROR_DIR" "Storage mirror dir (blank for google mode)" "" 0 0
+        ask_env "STORAGE_MIRROR_PATH" "Storage mirror path (blank for google mode)" "" 0 0
     else
         ask_env "STORAGE_PATH" "Google Drive folder ID, root, or folder path/name" "" 1 0
-        ask_env "STORAGE_MIRROR_DIR" "Local mirror directory" "$REPO_ROOT/.storage-mirror" 1 0
+        ask_env "STORAGE_MIRROR_PATH" "Local mirror path" "$REPO_ROOT/.storage-mirror" 1 0
     fi
 
     ask_env "QDRANT_HOST" "Qdrant host" "$(env_get QDRANT_HOST || true)" 1 0
     ask_env "OLLAMA_HOST" "Ollama host (fallback for local Ollama models)" "$(env_get OLLAMA_HOST || true)" 1 0
-    ask_env "LLM_MODEL" "LLM model" "$(env_first LLM_MODEL DEFAULT_LLM)" 1 0
+    ask_env "LLM_MODEL" "LLM model" "$(env_get LLM_MODEL || true)" 1 0
     ask_env "LLM_BASE_URL" "LLM base URL (blank for provider default)" "$(env_get LLM_BASE_URL || true)" 0 0
     ask_env "LLM_API_KEY" "LLM API key (blank if unused)" "$(env_get LLM_API_KEY || true)" 0 1
-    ask_env "DEFAULT_VLM" "Default VLM model" "$(env_get DEFAULT_VLM || true)" 1 0
-    ask_env "EMBEDDING_MODEL" "Embedding model" "$(env_first EMBEDDING_MODEL DEFAULT_EMBEDDINGS)" 1 0
+    ask_env "VLM_MODEL" "VLM model" "$(env_get VLM_MODEL || true)" 1 0
+    vlm_base_default=$(env_get VLM_BASE_URL || true)
+    if [ -z "$vlm_base_default" ]; then
+        vlm_base_default=$(env_get LLM_BASE_URL || true)
+    fi
+    vlm_key_default=$(env_get VLM_API_KEY || true)
+    if [ -z "$vlm_key_default" ]; then
+        vlm_key_default=$(env_get LLM_API_KEY || true)
+    fi
+    ask_env "VLM_BASE_URL" "VLM base URL (defaults to LLM_BASE_URL)" "$vlm_base_default" 0 0
+    ask_env "VLM_API_KEY" "VLM API key (defaults to LLM_API_KEY)" "$vlm_key_default" 0 1
+    ask_env "EMBEDDING_MODEL" "Embedding model" "$(env_get EMBEDDING_MODEL || true)" 1 0
     ask_env "EMBEDDING_BASE_URL" "Embedding base URL (blank for provider default)" "$(env_get EMBEDDING_BASE_URL || true)" 0 0
     ask_env "EMBEDDING_API_KEY" "Embedding API key (blank if unused)" "$(env_get EMBEDDING_API_KEY || true)" 0 1
-    # Keep compatibility aliases populated for older scripts and cached filenames.
-    env_set "DEFAULT_LLM" "$(env_get LLM_MODEL || true)"
-    env_set "DEFAULT_EMBEDDINGS" "$(env_get EMBEDDING_MODEL || true)"
     ask_env "GDRIVE_CREDENTIALS" "Google credentials path (blank to use default)" "$(env_get GDRIVE_CREDENTIALS || true)" 0 1
     ask_env "GDRIVE_TOKEN" "Google token path (blank to use default)" "$(env_get GDRIVE_TOKEN || true)" 0 1
     ask_env "GEMINI_API_KEY" "Gemini API key (blank if unused)" "$(env_get GEMINI_API_KEY || true)" 0 1
@@ -396,8 +393,8 @@ if [ "$INTERACTIVE" -eq 1 ]; then
     ask_env "DEALUM_API_KEY" "Dealum API key (blank if unused)" "$(env_get DEALUM_API_KEY || true)" 0 1
 else
     echo "[4/4] .env prompts skipped (--non-interactive)."
-    if [ -z "$(env_get REPO_DIR || true)" ]; then env_set "REPO_DIR" "$REPO_ROOT"; fi
-    if [ -z "$(env_get WORKSPACE_DIR || true)" ]; then env_set "WORKSPACE_DIR" "$TARGET"; fi
+    if [ -z "$(env_get REPO_PATH || true)" ]; then env_set "REPO_PATH" "$REPO_ROOT"; fi
+    if [ -z "$(env_get WORKSPACE_PATH || true)" ]; then env_set "WORKSPACE_PATH" "$TARGET"; fi
 fi
 
 echo

--- a/launch.sh
+++ b/launch.sh
@@ -87,12 +87,13 @@ ensure_ollama_model() {
 ensure_ollama_models() {
     local ollama_host="${OLLAMA_HOST:-http://localhost:11434}"
     local llm_host="${LLM_BASE_URL:-$ollama_host}"
+    local vlm_host="${VLM_BASE_URL:-$llm_host}"
     local embedding_host="${EMBEDDING_BASE_URL:-$ollama_host}"
-    local llm_model="${LLM_MODEL:-${DEFAULT_LLM:-}}"
-    local embedding_model="${EMBEDDING_MODEL:-${DEFAULT_EMBEDDINGS:-}}"
+    local llm_model="${LLM_MODEL:-}"
+    local embedding_model="${EMBEDDING_MODEL:-}"
 
     ensure_ollama_model "$llm_model" "LLM_MODEL" "$llm_host"
-    ensure_ollama_model "${DEFAULT_VLM:-}" "DEFAULT_VLM" "$ollama_host"
+    ensure_ollama_model "${VLM_MODEL:-}" "VLM_MODEL" "$vlm_host"
     ensure_ollama_model "$embedding_model" "EMBEDDING_MODEL" "$embedding_host"
 }
 

--- a/lib/adapters/docling.py
+++ b/lib/adapters/docling.py
@@ -46,10 +46,17 @@ def _build_converter():
         RapidOcrOptions,
     )
 
-    vlm_model_name = get_env_var("DEFAULT_VLM")
+    vlm_model_name = get_env_var("VLM_MODEL")
     if vlm_model_name.startswith("ollama/"):
         vlm_model_name = vlm_model_name[7:]
-    ollama_url = get_env_var("OLLAMA_HOST").rstrip("/")
+    vlm_base_url = (
+        os.environ.get("VLM_BASE_URL")
+        or os.environ.get("LLM_BASE_URL")
+        or os.environ.get("OLLAMA_HOST")
+        or "http://localhost:11434"
+    ).rstrip("/")
+    vlm_api_key = os.environ.get("VLM_API_KEY") or os.environ.get("LLM_API_KEY") or ""
+    headers = {"Authorization": f"Bearer {vlm_api_key}"} if vlm_api_key else {}
 
     if platform.system() == "Darwin":
         ocr_options = OcrMacOptions()
@@ -62,7 +69,8 @@ def _build_converter():
         enable_remote_services=True,  # needed for picture_description_options below
         ocr_options=ocr_options,
         picture_description_options=PictureDescriptionApiOptions(
-            url=f"{ollama_url}/v1/chat/completions",
+            url=f"{vlm_base_url}/v1/chat/completions",
+            headers=headers,
             params={"model": vlm_model_name, "max_tokens": 200},
             prompt="Describe this image in a few sentences.",
             timeout=600,

--- a/lib/adapters/linkedin.py
+++ b/lib/adapters/linkedin.py
@@ -359,13 +359,13 @@ def _get_global_registry_path() -> str:
     import os
     from lib.env import get_env_var
     try:
-        repo_dir = get_env_var("REPO_DIR")
-        if not repo_dir:
-            raise ValueError("REPO_DIR environment variable is empty.")
-        return os.path.join(repo_dir, "cache", "linkedin_missing_profiles.json")
+        repo_path = get_env_var("REPO_PATH")
+        if not repo_path:
+            raise ValueError("REPO_PATH environment variable is empty.")
+        return os.path.join(repo_path, "cache", "linkedin_missing_profiles.json")
     except Exception as e:
         logger.error(f"Failed to resolve global registry path: {e}")
-        raise RuntimeError("Missing required environment variable REPO_DIR. Aborting.")
+        raise RuntimeError("Missing required environment variable REPO_PATH. Aborting.")
 
 
 def linkedin_missing_profiles() -> List[Dict[str, Any]]:

--- a/lib/model_config.py
+++ b/lib/model_config.py
@@ -47,9 +47,7 @@ def _base_url_for_model(model: str, explicit: Optional[str]) -> Optional[str]:
 
 
 def llm_endpoint() -> ModelEndpoint:
-    model = _first_env("LLM_MODEL", "DEFAULT_LLM")
-    if not model:
-        model = get_env_var("DEFAULT_LLM")
+    model = get_env_var("LLM_MODEL")
     return ModelEndpoint(
         model=model,
         base_url=_base_url_for_model(model, _first_env("LLM_BASE_URL")),
@@ -58,9 +56,7 @@ def llm_endpoint() -> ModelEndpoint:
 
 
 def embedding_endpoint() -> ModelEndpoint:
-    model = _first_env("EMBEDDING_MODEL", "DEFAULT_EMBEDDINGS")
-    if not model:
-        model = get_env_var("DEFAULT_EMBEDDINGS")
+    model = get_env_var("EMBEDDING_MODEL")
     return ModelEndpoint(
         model=model,
         base_url=_base_url_for_model(model, _first_env("EMBEDDING_BASE_URL")),

--- a/lib/storage.py
+++ b/lib/storage.py
@@ -254,8 +254,8 @@ def get_storage() -> Storage:
 
     STORAGE_PROVIDER="local":  LocalStorage(STORAGE_PATH)
     STORAGE_PROVIDER="google": RoutedStorage with GoogleDriveStorage(STORAGE_PATH)
-                               for drive paths and LocalStorage($REPO_DIR/cache) for caches.
-    STORAGE_PROVIDER="hybrid": MirrorStorage — local mirror at STORAGE_MIRROR_DIR,
+                               for drive paths and LocalStorage($REPO_PATH/cache) for caches.
+    STORAGE_PROVIDER="hybrid": MirrorStorage — local mirror at STORAGE_MIRROR_PATH,
                                Drive as read-fallback and explicit sync target.
                                Markdown writes go local first, then upload to
                                Drive as Google Docs; cache/derived OCR paths
@@ -284,20 +284,20 @@ def get_storage() -> Storage:
             token_path=token_path,
             root_folder_id=root_folder_id
         )
-        repo_dir = os.environ.get("REPO_DIR")
-        cache_dir = os.path.join(repo_dir, "cache") if repo_dir else os.path.expanduser("~/.cache/sictic")
+        repo_path = os.environ.get("REPO_PATH")
+        cache_dir = os.path.join(repo_path, "cache") if repo_path else os.path.expanduser("~/.cache/sictic")
         os.makedirs(cache_dir, exist_ok=True)
         _storage_singleton = RoutedStorage(drive=drive, cache=LocalStorage(cache_dir))
     elif provider == "hybrid":
         from lib.storage_gdrive import GoogleDriveStorage
         from lib.storage_mirror import MirrorStorage
 
-        mirror_dir = get_env_var("STORAGE_MIRROR_DIR")
-        if not mirror_dir.startswith("/"):
+        mirror_path = get_env_var("STORAGE_MIRROR_PATH")
+        if not mirror_path.startswith("/"):
             raise ValueError(
-                f"STORAGE_MIRROR_DIR must be an absolute path, got: {mirror_dir}"
+                f"STORAGE_MIRROR_PATH must be an absolute path, got: {mirror_path}"
             )
-        os.makedirs(mirror_dir, exist_ok=True)
+        os.makedirs(mirror_path, exist_ok=True)
 
         credentials_path = os.environ.get("GDRIVE_CREDENTIALS") or os.path.expanduser("~/.openclaw/gdrive-ops-credentials.json")
         token_path = os.environ.get("GDRIVE_TOKEN") or os.path.expanduser("~/.openclaw/gdrive-ops-token.json")
@@ -308,7 +308,7 @@ def get_storage() -> Storage:
             token_path=token_path,
             root_folder_id=root_folder_id,
         )
-        _storage_singleton = MirrorStorage(local=LocalStorage(mirror_dir), drive=drive)
+        _storage_singleton = MirrorStorage(local=LocalStorage(mirror_path), drive=drive)
     else:
         # Local mode requires an absolute path
         base_dir = get_env_var("STORAGE_PATH")

--- a/lib/storage_domains.py
+++ b/lib/storage_domains.py
@@ -42,7 +42,7 @@ class DatasetLocation:
 
 
 def _config_path() -> Path:
-    return Path(get_env_var("REPO_DIR")) / "config" / "storage_domains.json"
+    return Path(get_env_var("REPO_PATH")) / "config" / "storage_domains.json"
 
 
 @lru_cache(maxsize=1)

--- a/scripts/gdrive_sync.py
+++ b/scripts/gdrive_sync.py
@@ -1,5 +1,5 @@
 """
-Cleanly mirror files between STORAGE_MIRROR_DIR and Google Drive.
+Cleanly mirror files between STORAGE_MIRROR_PATH and Google Drive.
 
   pull [path]: Drive -> local. Drive is source of truth.
   push [path]: local -> Drive. Local mirror is source of truth.
@@ -171,12 +171,12 @@ def _push_file(mirror: LocalStorage, drive: GoogleDriveStorage, rel: str, source
 
 def _build_sync_context(
     *,
-    mirror_dir: Optional[str],
+    mirror_path: Optional[str],
     root_folder_id: Optional[str],
     credentials: Optional[str],
     token: Optional[str],
 ) -> Tuple[LocalStorage, GoogleDriveStorage]:
-    mirror_dir = mirror_dir or os.environ.get("STORAGE_MIRROR_DIR")
+    mirror_path = mirror_path or os.environ.get("STORAGE_MIRROR_PATH")
     root_folder_id = root_folder_id or os.environ.get("STORAGE_PATH") or get_env_var("STORAGE_PATH")
     credentials = (
         credentials
@@ -189,14 +189,14 @@ def _build_sync_context(
         or os.path.expanduser("~/.openclaw/gdrive-ops-token.json")
     )
 
-    if not mirror_dir:
-        raise ValueError("STORAGE_MIRROR_DIR is not set and --mirror-dir not given.")
-    if not mirror_dir.startswith("/"):
-        raise ValueError(f"mirror dir must be absolute, got: {mirror_dir}")
-    os.makedirs(mirror_dir, exist_ok=True)
+    if not mirror_path:
+        raise ValueError("STORAGE_MIRROR_PATH is not set and --mirror-path not given.")
+    if not mirror_path.startswith("/"):
+        raise ValueError(f"mirror path must be absolute, got: {mirror_path}")
+    os.makedirs(mirror_path, exist_ok=True)
 
     return (
-        LocalStorage(mirror_dir),
+        LocalStorage(mirror_path),
         _build_drive_storage(root_folder_id, credentials, token),
     )
 
@@ -204,7 +204,7 @@ def _build_sync_context(
 def pull_mirror(
     rel: Optional[str] = None,
     *,
-    mirror_dir: Optional[str] = None,
+    mirror_path: Optional[str] = None,
     root_folder_id: Optional[str] = None,
     credentials: Optional[str] = None,
     token: Optional[str] = None,
@@ -213,7 +213,7 @@ def pull_mirror(
     rel = _clean_rel(rel)
     try:
         mirror, drive = _build_sync_context(
-            mirror_dir=mirror_dir,
+            mirror_path=mirror_path,
             root_folder_id=root_folder_id,
             credentials=credentials,
             token=token,
@@ -256,7 +256,7 @@ def pull_mirror(
 def push_mirror(
     rel: Optional[str] = None,
     *,
-    mirror_dir: Optional[str] = None,
+    mirror_path: Optional[str] = None,
     root_folder_id: Optional[str] = None,
     credentials: Optional[str] = None,
     token: Optional[str] = None,
@@ -265,7 +265,7 @@ def push_mirror(
     rel = _clean_rel(rel)
     try:
         mirror, drive = _build_sync_context(
-            mirror_dir=mirror_dir,
+            mirror_path=mirror_path,
             root_folder_id=root_folder_id,
             credentials=credentials,
             token=token,
@@ -314,9 +314,9 @@ def main() -> int:
         help="Optional relative path under the configured storage root.",
     )
     parser.add_argument(
-        "--mirror-dir",
-        default=os.environ.get("STORAGE_MIRROR_DIR"),
-        help="Local mirror dir (default: $STORAGE_MIRROR_DIR).",
+        "--mirror-path",
+        default=os.environ.get("STORAGE_MIRROR_PATH"),
+        help="Local mirror path (default: $STORAGE_MIRROR_PATH).",
     )
     parser.add_argument(
         "--root-folder-id",
@@ -338,14 +338,14 @@ def main() -> int:
     if args.direction == "pull":
         return pull_mirror(
             args.path,
-            mirror_dir=args.mirror_dir,
+            mirror_path=args.mirror_path,
             root_folder_id=args.root_folder_id,
             credentials=args.credentials,
             token=args.token,
         )
     return push_mirror(
         args.path,
-        mirror_dir=args.mirror_dir,
+        mirror_path=args.mirror_path,
         root_folder_id=args.root_folder_id,
         credentials=args.credentials,
         token=args.token,

--- a/skills/config_load/SKILL.md
+++ b/skills/config_load/SKILL.md
@@ -18,4 +18,4 @@ Compiles Markdown-based configuration files from a Google Drive rclone mount int
 
 **Prerequisites:**
 - All runtime dependencies (including `rich`) are installed in the project venv at `the Conda environment ` by `{{REPO_ROOT}}/install_skills.sh`.
-- The Google Drive must be mounted via rclone to the path set in `REPOSITORY_DIR` (see `.env`).
+- The Google Drive must be mounted via rclone to the path set in `REPO_PATH` (see `.env`).

--- a/skills/config_load/config_load.py
+++ b/skills/config_load/config_load.py
@@ -8,11 +8,11 @@ from lib.logger import get_logger
 logger = get_logger(__name__)
 
 # The single source of truth is now the local Git repository's config folder.
-REPO_ROOT = Path(get_env_var("REPO_DIR"))
+REPO_ROOT = Path(get_env_var("REPO_PATH"))
 SOURCE_DIR = REPO_ROOT / "config"
 
 def _local_cache_paths() -> tuple[Path, Path]:
-    """Local cache lives in the configured REPO_DIR/cache."""
+    """Local cache lives in the configured REPO_PATH/cache."""
     cache_dir = REPO_ROOT / "cache"
     cache_file = cache_dir / "config.json"
     return cache_dir, cache_file

--- a/skills/dataset_chat/SKILL.md
+++ b/skills/dataset_chat/SKILL.md
@@ -16,7 +16,7 @@ The following environment variables must be present in the repo's `.env` file (`
 - `DOCLING_HOST`: e.g., `http://localhost:5001`
 - `OLLAMA_HOST`: e.g., `http://localhost:11434`
 - `RCLONE_HOST`: e.g., `http://localhost:5572`
-- `DEFAULT_VLM`: Used by Docling-Serve/Ollama for image-to-text generation.
+- `VLM_MODEL`: Used by Docling-Serve/Ollama for image-to-text generation.
 - `EMBEDDING_MODEL`: Model used for vector embeddings.
 - `EMBEDDING_BASE_URL`: Optional endpoint base URL. Use `http://localhost:11434` for local Ollama.
 - `EMBEDDING_API_KEY`: Optional endpoint API key. Leave blank for local Ollama.

--- a/skills/dd_checks/SKILL.md
+++ b/skills/dd_checks/SKILL.md
@@ -22,7 +22,7 @@ The skill executes a python script in the background that manages the process:
    3. For each chapter, it selects the key that matches the identified `<industry_type>`. If an industry-specific version doesn't exist for that chapter, it falls back to the `general` version.
 3. **Comprehensive Review:** For each selected checklist, it uses `batch_audit` to process all items against the data room.
 4. **Resiliency:** If a chapter fails (e.g., LLM timeout, context window limit), the script logs the error inside the Markdown output file for that specific chapter, safely catches the exception, and continues processing the remaining chapters.
-5. **Output:** All chapter results are collated and saved to a file named `<STARTUP_NAME>_dd_checks_<MODEL_NAME>.md` inside the directory `<REPOSITORY_DIR>/insights/<STARTUP_NAME>/`. Each chapter's findings are appended to this file as soon as they become available.
+5. **Output:** All chapter results are collated and saved to a file named `<STARTUP_NAME>_dd_checks_<MODEL_NAME>.md` inside the directory `<REPO_PATH>/insights/<STARTUP_NAME>/`. Each chapter's findings are appended to this file as soon as they become available.
 
 ## Usage
 

--- a/skills/investor_appetite/SKILL.md
+++ b/skills/investor_appetite/SKILL.md
@@ -23,7 +23,7 @@ description: Determines the ideal startup profile for one or more investors base
      * **Filename Generation & Caching:**
        * Sanitize `investor_name` into a safe string.
        * Determine the model suffix dynamically via the configured `LLM_MODEL`.
-       * Construct the output file path: `<REPOSITORY_DIR>/insights/sictic_members/investor_appetite/<sanitized_name>_<model_name>.md`.
+       * Construct the output file path: `<REPO_PATH>/insights/sictic_members/investor_appetite/<sanitized_name>_<model_name>.md`.
        * Use the `check_insight_refresh` utility (dataset: `"sictic_members"`, file: `"investor_appetite/<sanitized_name>_<model_name>.md"`). 
        * If a refresh is not needed and the file exists, read its contents, append to the result dictionary, and skip to the next investor.
      * **Retrieve Person Profile:**

--- a/skills/person_profile/SKILL.md
+++ b/skills/person_profile/SKILL.md
@@ -15,7 +15,7 @@ description: Collate a comprehensive profile on a specific person by searching a
 
 1. **Filename Generation & Caching:** 
    * Sanitize the input `name` into a safe string.
-   * Construct the output file path: `<REPOSITORY_DIR>/insights/<dataset_name>/profile_<sanitized_name>_<model_name>.md`.
+   * Construct the output file path: `<REPO_PATH>/insights/<dataset_name>/profile_<sanitized_name>_<model_name>.md`.
    * Check if this file already exists using the `check_insight_refresh` utility. If it does, read and return its contents immediately, bypassing the LLM.
 
 2. **Data Retrieval & Synthesis:**

--- a/skills/potential_investors/SKILL.md
+++ b/skills/potential_investors/SKILL.md
@@ -49,7 +49,7 @@ description: This skill aims to find potential investors in the target startup. 
 
 4. **Output Generation:** 
    * Construct a final Markdown string containing a table of the ranked results: `| Investor Name | Score | Rationale |`. 
-   * Save this Markdown table to: `<REPOSITORY_DIR>/insights/<startup_name>/<startup_name>_potential_investors_<model_name>.md`. 
+   * Save this Markdown table to: `<REPO_PATH>/insights/<startup_name>/<startup_name>_potential_investors_<model_name>.md`. 
    * Return the Markdown string.
 
 **CLI Interface:**

--- a/skills/sictic_git_sync/sictic_git_sync.py
+++ b/skills/sictic_git_sync/sictic_git_sync.py
@@ -18,7 +18,7 @@ def run_cmd(cmd: list[str], cwd: Path) -> str:
 
 def _reconcile_symlinks(repo_dir: Path, workspace_dir: Path) -> list[str]:
     """
-    Enforces a strict 1:1 mapping between REPO_DIR/skills and WORKSPACE_DIR.
+    Enforces a strict 1:1 mapping between REPO_PATH/skills and WORKSPACE_PATH.
     1. Removes broken symlinks.
     2. Moves raw folders from workspace to repo and replaces with symlinks.
     3. Creates missing symlinks for new repo folders.
@@ -70,8 +70,8 @@ def _reconcile_symlinks(repo_dir: Path, workspace_dir: Path) -> list[str]:
 
 async def sictic_git_sync(action: str, message: str = "") -> str:
     """Main orchestration for git sync and symlink parity."""
-    repo_dir = Path(get_env_var("REPO_DIR"))
-    workspace_dir = Path(get_env_var("WORKSPACE_DIR"))
+    repo_dir = Path(get_env_var("REPO_PATH"))
+    workspace_dir = Path(get_env_var("WORKSPACE_PATH"))
     
     output = []
     

--- a/skills/startup_traction/SKILL.md
+++ b/skills/startup_traction/SKILL.md
@@ -19,7 +19,7 @@ Use this skill when the user asks to summarize, extract, or list traction, comme
 1. **Filename Generation & Caching:** 
    * Convert `startup_name` to lowercase. 
    * Determine the current model suffix (e.g., `qwen3.5_9b`). 
-   * Construct the output file path: `<REPOSITORY_DIR>/insights/<startup_name>/<startup_name>_traction_<model_name>.md`. 
+   * Construct the output file path: `<REPO_PATH>/insights/<startup_name>/<startup_name>_traction_<model_name>.md`. 
    * Call `check_insight_refresh([startup_name], "<startup_name>_traction_<model_suffix>.md")`. If it returns `False` (no refresh needed), read the existing file from disk and return its contents immediately.
 
 2. **Configuration Loading:** 
@@ -35,7 +35,7 @@ Use this skill when the user asks to summarize, extract, or list traction, comme
    * *Note:* Ensure `dataset_chat` returns the raw Markdown string directly, as we expect a combined table and synthesis rather than a strictly parsed JSON object.
 
 4. **Output Generation:** 
-   * Ensure the output directory `<REPOSITORY_DIR>/insights/<startup_name>/` exists. 
+   * Ensure the output directory `<REPO_PATH>/insights/<startup_name>/` exists. 
    * Write the returned Markdown string to the constructed output file path. 
    * Log success using the centralized `logger`. 
    * Return the raw Markdown string to the user/CLI.

--- a/skills/suggested_startups/SKILL.md
+++ b/skills/suggested_startups/SKILL.md
@@ -45,7 +45,7 @@ description: Rank a provided list of startups against a list of investors by mat
  
  | :--- | :--- | :--- | :--- | 
  
-5. **Output Generation:** Save the final Markdown table to the following path: `<REPOSITORY_DIR>/insights/sictic_members/suggested_startups_<model_name>.md`
+5. **Output Generation:** Save the final Markdown table to the following path: `<REPO_PATH>/insights/sictic_members/suggested_startups_<model_name>.md`
 
 ## Usage
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,8 +9,8 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 # Import once so lib.env loads any local .env before tests force safe values.
 import lib.env  # noqa: E402,F401
 
-os.environ["REPO_DIR"] = str(REPO_ROOT)
-os.environ["WORKSPACE_DIR"] = str(REPO_ROOT / "skills")
+os.environ["REPO_PATH"] = str(REPO_ROOT)
+os.environ["WORKSPACE_PATH"] = str(REPO_ROOT / "skills")
 os.environ["STORAGE_PROVIDER"] = "local"
 os.environ["STORAGE_PATH"] = str(REPO_ROOT / ".pytest-storage")
 os.environ["LLM_MODEL"] = "ollama/test_model:1b"
@@ -19,9 +19,9 @@ os.environ["LLM_API_KEY"] = ""
 os.environ["EMBEDDING_MODEL"] = "ollama/test-embedding:8b"
 os.environ["EMBEDDING_BASE_URL"] = "http://localhost:11434"
 os.environ["EMBEDDING_API_KEY"] = ""
-os.environ["DEFAULT_LLM"] = "ollama/test_model:1b"
-os.environ["DEFAULT_VLM"] = "ollama/test-vlm:1b"
-os.environ["DEFAULT_EMBEDDINGS"] = "ollama/test-embedding:8b"
+os.environ["VLM_MODEL"] = "ollama/test-vlm:1b"
+os.environ["VLM_BASE_URL"] = "http://localhost:11434"
+os.environ["VLM_API_KEY"] = ""
 os.environ["OLLAMA_HOST"] = "http://localhost:11434"
 os.environ["QDRANT_HOST"] = "http://localhost:6333"
 os.environ["OLLAMA_NUM_CTX"] = "4096"
@@ -62,7 +62,7 @@ def pytest_pyfunc_call(pyfuncitem):
 def mock_env(monkeypatch, tmp_path):
     """
     Sets up a safe, isolated environment for tests.
-    It overrides REPOSITORY_DIR and WORKSPACE_DIR to point to a temporary directory
+    It overrides REPO_PATH and WORKSPACE_PATH to point to a temporary directory
     so that no real files are ever affected during unit testing.
     """
     # Create mock directories
@@ -75,17 +75,17 @@ def mock_env(monkeypatch, tmp_path):
     # Override environment variables
     monkeypatch.setenv("STORAGE_PROVIDER", "local")
     monkeypatch.setenv("STORAGE_PATH", str(repository_dir_mock))
-    monkeypatch.setenv("REPO_DIR", str(Path(__file__).resolve().parents[1]))
-    monkeypatch.setenv("WORKSPACE_DIR", str(workspace_mock))
+    monkeypatch.setenv("REPO_PATH", str(Path(__file__).resolve().parents[1]))
+    monkeypatch.setenv("WORKSPACE_PATH", str(workspace_mock))
     monkeypatch.setenv("LLM_MODEL", "ollama/test_model:1b")
     monkeypatch.setenv("LLM_BASE_URL", "http://localhost:11434")
     monkeypatch.setenv("LLM_API_KEY", "")
     monkeypatch.setenv("EMBEDDING_MODEL", "ollama/test-embedding:8b")
     monkeypatch.setenv("EMBEDDING_BASE_URL", "http://localhost:11434")
     monkeypatch.setenv("EMBEDDING_API_KEY", "")
-    monkeypatch.setenv("DEFAULT_LLM", "ollama/test_model:1b")
-    monkeypatch.setenv("DEFAULT_VLM", "ollama/test-vlm:1b")
-    monkeypatch.setenv("DEFAULT_EMBEDDINGS", "ollama/test-embedding:8b")
+    monkeypatch.setenv("VLM_MODEL", "ollama/test-vlm:1b")
+    monkeypatch.setenv("VLM_BASE_URL", "http://localhost:11434")
+    monkeypatch.setenv("VLM_API_KEY", "")
     monkeypatch.setenv("OLLAMA_HOST", "http://localhost:11434")
     monkeypatch.setenv("QDRANT_HOST", "http://localhost:6333")
     monkeypatch.setenv("OLLAMA_NUM_CTX", "4096")

--- a/tests/expert_search/test_expert_search_integration.py
+++ b/tests/expert_search/test_expert_search_integration.py
@@ -16,7 +16,7 @@ TEST_CASES = [
 def check_dataset_exists(startup):
     """Check if required datasets exist in the local workspace."""
     try:
-        repository_dir = get_env_var("REPOSITORY_DIR")
+        repository_dir = get_env_var("REPO_PATH")
     except Exception:
         return False
         

--- a/tests/qdrant/test_qdrant_adapter.py
+++ b/tests/qdrant/test_qdrant_adapter.py
@@ -9,7 +9,7 @@ from skills.dataset_chat.core.models import Chunk
 @pytest.fixture
 def mock_env(monkeypatch):
     """Mock the environment variables required by QdrantAdapter."""
-    monkeypatch.setenv("DEFAULT_EMBEDDINGS", "ollama/test-embedding:8b")
+    monkeypatch.setenv("EMBEDDING_MODEL", "ollama/test-embedding:8b")
     monkeypatch.setenv("OLLAMA_HOST", "http://localhost:11434")
     # Suppress console warnings for tests
     monkeypatch.setenv("GRPC_VERBOSITY", "ERROR")

--- a/tests/utils/test_model_config.py
+++ b/tests/utils/test_model_config.py
@@ -2,7 +2,6 @@ from lib.model_config import embedding_endpoint, llm_endpoint
 
 
 def test_llm_endpoint_prefers_explicit_llm_vars(monkeypatch):
-    monkeypatch.setenv("DEFAULT_LLM", "ollama/old:1b")
     monkeypatch.setenv("OLLAMA_HOST", "http://localhost:11434")
     monkeypatch.setenv("LLM_MODEL", "openai/gpt-4.1-mini")
     monkeypatch.setenv("LLM_BASE_URL", "https://llm.example.test/v1")
@@ -21,7 +20,6 @@ def test_llm_endpoint_prefers_explicit_llm_vars(monkeypatch):
 
 
 def test_embedding_endpoint_prefers_explicit_embedding_vars(monkeypatch):
-    monkeypatch.setenv("DEFAULT_EMBEDDINGS", "ollama/old-embed:1b")
     monkeypatch.setenv("EMBEDDING_MODEL", "openai/text-embedding-3-small")
     monkeypatch.setenv("EMBEDDING_BASE_URL", "https://embed.example.test/v1")
     monkeypatch.setenv("EMBEDDING_API_KEY", "embed-key")

--- a/tests/utils/test_storage_api_smoke.py
+++ b/tests/utils/test_storage_api_smoke.py
@@ -1,7 +1,7 @@
 """
 Smoke-test every Storage protocol method against the LIVE backend selected by
 GDRIVE_USE_API. With GDRIVE_USE_API=1 this exercises GoogleDriveStorage; without
-it, LocalStorage(REPOSITORY_DIR). Same assertions either way.
+it, LocalStorage(REPO_PATH). Same assertions either way.
 
 If every method passes here, then every skill that uses these methods (which is
 all of them, since the static scan confirmed no direct-FS) will be wired up
@@ -141,23 +141,19 @@ def test_refresh_does_not_raise(s):
     s.refresh(PREFIX)
 
 
-def test_absolute_path_normalization(s):
-    """The legacy-compat shim in lib/storage.py: absolute paths under
-    REPOSITORY_DIR get stripped to relative. Anywhere else → ValueError."""
+def test_absolute_paths_are_rejected(s):
+    """Storage API callers must pass relative paths, not local filesystem paths."""
     rel = f"{PREFIX}/normtest.txt"
     s.write_text(rel, "hi")
-    # Absolute path that happens to be under REPOSITORY_DIR should resolve to the same file.
-    mount = os.environ.get("REPOSITORY_DIR", "").rstrip("/")
+
+    mount = os.environ.get("REPO_PATH", "").rstrip("/")
     if mount:
         abs_path = f"{mount}/{rel}"
-        assert s.read_text(abs_path) == "hi"
-    # Absolute path OUTSIDE REPOSITORY_DIR should be rejected.
-    raised = False
-    try:
+        with pytest.raises(ValueError):
+            s.read_text(abs_path)
+
+    with pytest.raises(ValueError):
         s.read_text("/etc/passwd")
-    except ValueError:
-        raised = True
-    assert raised, "absolute path outside REPOSITORY_DIR should raise ValueError"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- clean up README wording, section structure, and formatting
- rename path-related env vars from *_DIR to *_PATH across code, docs, tests, and installer
- replace DEFAULT_* model env names with LLM_MODEL, EMBEDDING_MODEL, and VLM_MODEL; add VLM_BASE_URL and VLM_API_KEY

## Tests
- conda run -n sictic-env python -m pytest tests/utils/test_model_config.py tests/config_load/test_config_load.py -q
- focused storage/model checks run during cleanup