### PR TITLE
[codex] Prepare expert discovery for deep dives

### DIFF
--- a/config/startup_profile/llm_instructions.md
+++ b/config/startup_profile/llm_instructions.md
@@ -3,5 +3,4 @@ You are a skeptical, cynical venture capital analyst. Your job is to ignore all 
 
 Use only facts present in the provided context. Do not infer generic market size, competitors, cloud providers, CAC, churn, regulatory issues, patents, lawsuits, or financial metrics unless the context explicitly states them. If a field is not supported by the context, write "Not found in provided documents" for that part.
 
-Please profile this startup. Always generate EXACTLY the bullet points following this specific output template above. 
-
+Please profile this startup. Start with the startup name. Always generate EXACTLY the bullet points following this specific output template above.

--- a/lib/adapters/dealum.py
+++ b/lib/adapters/dealum.py
@@ -9,7 +9,6 @@ from urllib.parse import unquote, urlparse
 import requests
 
 from lib.logger import get_logger
-from lib.slugify import slugify
 
 logger = get_logger(__name__)
 
@@ -52,32 +51,18 @@ class DealumAdapter:
         if not self.dealroom_id:
             raise ValueError("DEALUM_DEALROOM_ID is not configured.")
         url = f"{self.base_url}/dealrooms/{self.dealroom_id}/applications"
+        logger.info("[dealum-api] Listing applications: dealroom_id=%s", self.dealroom_id)
         response = requests.get(url, headers=self._headers(), timeout=self.timeout)
         response.raise_for_status()
         data = response.json()
         if not isinstance(data, list):
             raise ValueError("Dealum applications response was not a list.")
+        logger.info(
+            "[dealum-api] Listed %d applications: dealroom_id=%s",
+            len(data),
+            self.dealroom_id,
+        )
         return data
-
-    def find_application(self, startup: str) -> Optional[dict[str, Any]]:
-        target_slug = slugify(startup)
-        target_lower = startup.strip().lower()
-        applications = self.list_applications()
-
-        for application in applications:
-            if slugify(str(application.get("name", ""))) == target_slug:
-                return application
-            if str(application.get("code", "")).strip().lower() == target_lower:
-                return application
-
-        for application in applications:
-            blob = " ".join(
-                str(application.get(key, ""))
-                for key in ("name", "code")
-            ).lower()
-            if target_lower and target_lower in blob:
-                return application
-        return None
 
     def extract_file_links(self, application: dict[str, Any]) -> list[DealumFileLink]:
         answers = application.get("answers") or {}

--- a/lib/dealum_import.py
+++ b/lib/dealum_import.py
@@ -8,6 +8,7 @@ from typing import Any, Optional
 
 from lib.adapters.dealum import DealumAdapter, DealumFileLink
 from lib.logger import get_logger
+from lib.slugify import slugify
 from lib.startup_dossier import canonical_startup_slug, ensure_startup_dossier
 from lib.storage import get_storage
 from lib.storage_domains import (
@@ -22,6 +23,7 @@ DEALUM_SUBDIR = "dealum"
 APPLICATION_MD = "application.md"
 APPLICATION_RAW_JSON = "application.raw.json"
 MANIFEST_JSON = "manifest.json"
+DEALUM_APP_URL = "https://app.dealum.com/#/dealroom/{dealroom_id}?application={application_id}"
 
 
 @dataclass(frozen=True)
@@ -31,12 +33,42 @@ class DealumImportResult:
     imported: bool
     changed: bool
     application_found: bool
+    dealum_name: Optional[str] = None
+    dealum_id: Any = None
+    dealum_url: Optional[str] = None
+    application_code: Optional[str] = None
+    match_method: Optional[str] = None
     manifest_path: Optional[str] = None
     application_path: Optional[str] = None
     downloaded_files: int = 0
     skipped_files: int = 0
     stale_files: int = 0
     step: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class DealumMatch:
+    requested_startup: str
+    matched_name: str
+    dataset_slug: str
+    dealum_id: Any
+    dealum_url: Optional[str]
+    application_code: Optional[str]
+    step: Optional[str]
+    match_method: str
+    application: dict[str, Any]
+
+
+class DealumReconciliationError(ValueError):
+    """Base error for startup-name reconciliation against Dealum."""
+
+
+class DealumApplicationNotFoundError(DealumReconciliationError):
+    """Raised when no exact Dealum name or application code matches."""
+
+
+class DealumApplicationAmbiguousError(DealumReconciliationError):
+    """Raised when an exact lookup identifies more than one application."""
 
 
 def dealum_dataset_rel(dataset_slug: str) -> str:
@@ -47,6 +79,152 @@ def dealum_manifest_path(dataset_slug: str) -> str:
     return f"{dealum_dataset_rel(dataset_slug)}/{MANIFEST_JSON}"
 
 
+def dealum_application_url(
+    dealroom_id: Optional[str],
+    application_id: Any,
+) -> Optional[str]:
+    if not dealroom_id or application_id in (None, ""):
+        return None
+    return DEALUM_APP_URL.format(
+        dealroom_id=dealroom_id,
+        application_id=application_id,
+    )
+
+
+def reconcile_dealum_startup(
+    startup: str,
+    *,
+    adapter: Optional[DealumAdapter] = None,
+) -> DealumMatch:
+    requested = startup.strip()
+    if not requested:
+        raise DealumReconciliationError("Provide a startup name or Dealum application code.")
+
+    adapter = adapter or DealumAdapter()
+    if not adapter.is_configured():
+        raise ValueError("Dealum is not configured. Set DEALUM_API_KEY and DEALUM_DEALROOM_ID.")
+
+    target_slug = slugify(requested)
+    target_code = requested.casefold()
+    logger.info(
+        "[dealum-reconcile] Starting reconciliation: requested=%r normalized=%r",
+        requested,
+        target_slug,
+    )
+
+    try:
+        applications = adapter.list_applications()
+    except Exception:
+        logger.exception(
+            "[dealum-reconcile] Failed to retrieve Dealum applications: requested=%r",
+            requested,
+        )
+        raise
+
+    logger.info(
+        "[dealum-reconcile] Retrieved %d Dealum applications for requested=%r",
+        len(applications),
+        requested,
+    )
+
+    name_matches = [
+        application
+        for application in applications
+        if slugify(str(application.get("name") or "")) == target_slug
+    ]
+    logger.debug(
+        "[dealum-reconcile] Normalized-name phase found %d matches: requested=%r normalized=%r",
+        len(name_matches),
+        requested,
+        target_slug,
+    )
+    if name_matches:
+        return _dealum_match(requested, name_matches, "normalized_name", adapter.dealroom_id)
+
+    code_matches = [
+        application
+        for application in applications
+        if str(application.get("code") or "").strip().casefold() == target_code
+    ]
+    logger.debug(
+        "[dealum-reconcile] Application-code phase found %d matches: requested=%r",
+        len(code_matches),
+        requested,
+    )
+    if code_matches:
+        return _dealum_match(requested, code_matches, "application_code", adapter.dealroom_id)
+
+    logger.warning(
+        "[dealum-reconcile] No exact match: requested=%r normalized=%r applications_checked=%d",
+        requested,
+        target_slug,
+        len(applications),
+    )
+    raise DealumApplicationNotFoundError(
+        f"No exact Dealum application match for '{requested}'. "
+        "Provide the startup name as shown in Dealum or its application code."
+    )
+
+
+def _dealum_match(
+    requested: str,
+    applications: list[dict[str, Any]],
+    match_method: str,
+    dealroom_id: Optional[str],
+) -> DealumMatch:
+    if len(applications) > 1:
+        candidates = [
+            {
+                "name": application.get("name"),
+                "id": application.get("id"),
+                "code": application.get("code"),
+                "step": application.get("step"),
+            }
+            for application in applications
+        ]
+        logger.error(
+            "[dealum-reconcile] Ambiguous exact match: requested=%r method=%s candidates=%s",
+            requested,
+            match_method,
+            candidates,
+        )
+        candidate_names = ", ".join(
+            f"{item.get('name') or 'unnamed'} ({item.get('code') or item.get('id') or 'no identifier'})"
+            for item in candidates
+        )
+        raise DealumApplicationAmbiguousError(
+            f"Multiple Dealum applications match '{requested}': {candidate_names}."
+        )
+
+    application = applications[0]
+    matched_name = str(application.get("name") or requested).strip()
+    dataset_slug = canonical_startup_slug(matched_name)
+    match = DealumMatch(
+        requested_startup=requested,
+        matched_name=matched_name,
+        dataset_slug=dataset_slug,
+        dealum_id=application.get("id"),
+        dealum_url=dealum_application_url(dealroom_id, application.get("id")),
+        application_code=application.get("code"),
+        step=application.get("step"),
+        match_method=match_method,
+        application=application,
+    )
+    logger.info(
+        "[dealum-reconcile] Matched requested=%r to name=%r id=%r code=%r step=%r "
+        "method=%s dataset_slug=%r url=%r",
+        requested,
+        match.matched_name,
+        match.dealum_id,
+        match.application_code,
+        match.step,
+        match.match_method,
+        match.dataset_slug,
+        match.dealum_url,
+    )
+    return match
+
+
 def import_startup_from_dealum(
     startup: str,
     *,
@@ -55,21 +233,17 @@ def import_startup_from_dealum(
     download_documents: bool = True,
 ) -> DealumImportResult:
     adapter = adapter or DealumAdapter()
-    if not adapter.is_configured():
-        raise ValueError("Dealum is not configured. Set DEALUM_API_KEY and DEALUM_DEALROOM_ID.")
-
-    application = adapter.find_application(startup)
-    dataset_slug = canonical_startup_slug(
-        application.get("name", startup) if application else startup
+    logger.info("[dealum-import] Starting import: requested=%r", startup)
+    match = reconcile_dealum_startup(startup, adapter=adapter)
+    application = match.application
+    dataset_slug = match.dataset_slug
+    logger.info(
+        "[dealum-import] Reconciliation complete: requested=%r matched=%r method=%s dataset_slug=%r",
+        startup,
+        match.matched_name,
+        match.match_method,
+        dataset_slug,
     )
-    if not application:
-        return DealumImportResult(
-            startup=startup,
-            dataset_slug=dataset_slug,
-            imported=False,
-            changed=False,
-            application_found=False,
-        )
 
     storage = get_storage()
     active_marker = dataset_active_marker_path(dataset_slug)
@@ -88,14 +262,26 @@ def import_startup_from_dealum(
     previous_manifest = _read_manifest(dataset_slug)
     answer_hash = _stable_hash(_application_content_for_hash(application))
     application_changed = answer_hash != previous_manifest.get("application_hash")
+    dealum_url_changed = match.dealum_url != previous_manifest.get("dealum_url")
 
     application_path = f"{dealum_rel}/{APPLICATION_MD}"
     raw_json_path = f"{dealum_rel}/{APPLICATION_RAW_JSON}"
     manifest_path = dealum_manifest_path(dataset_slug)
 
     changed = dossier_changed
-    if application_changed or not storage.exists(application_path):
-        storage.write_text(application_path, render_application_markdown(application))
+    if application_changed or dealum_url_changed or not storage.exists(application_path):
+        logger.info(
+            "[dealum-import] Writing Dealum application: dataset_slug=%r "
+            "application_changed=%s dealum_url_changed=%s path=%s",
+            dataset_slug,
+            application_changed,
+            dealum_url_changed,
+            application_path,
+        )
+        storage.write_text(
+            application_path,
+            render_application_markdown(application, dealum_url=match.dealum_url),
+        )
         storage.write_text(raw_json_path, _stable_json(application))
         changed = True
 
@@ -131,6 +317,12 @@ def import_startup_from_dealum(
                     logger.warning(f"[{dataset_slug}] Dealum file metadata check failed for {link.url}: {e}")
 
             if should_download:
+                logger.info(
+                    "[dealum-import] Downloading linked file: dataset_slug=%r field=%r target=%s",
+                    dataset_slug,
+                    link.field,
+                    target_rel,
+                )
                 content, download_metadata = adapter.download_file(link.url)
                 storage.write_bytes(target_rel, content)
                 metadata.update(download_metadata)
@@ -138,6 +330,11 @@ def import_startup_from_dealum(
                 downloaded_files += 1
                 changed = True
             else:
+                logger.debug(
+                    "[dealum-import] Linked file unchanged: dataset_slug=%r target=%s",
+                    dataset_slug,
+                    target_rel,
+                )
                 metadata.update({k: v for k, v in previous.items() if k not in metadata or metadata[k] is None})
                 skipped_files += 1
 
@@ -156,6 +353,7 @@ def import_startup_from_dealum(
         "startup": application.get("name") or startup,
         "dataset_slug": dataset_slug,
         "dealum_id": application.get("id"),
+        "dealum_url": match.dealum_url,
         "code": application.get("code"),
         "step": application.get("step"),
         "tags": application.get("tags") or [],
@@ -171,12 +369,29 @@ def import_startup_from_dealum(
         storage.write_text(manifest_path, _stable_json(manifest))
         changed = True
 
+    logger.info(
+        "[dealum-import] Completed import: requested=%r matched=%r dataset_slug=%r changed=%s "
+        "downloaded=%d skipped=%d stale=%d step=%r",
+        startup,
+        match.matched_name,
+        dataset_slug,
+        changed,
+        downloaded_files,
+        skipped_files,
+        stale_files,
+        match.step,
+    )
     return DealumImportResult(
         startup=startup,
         dataset_slug=dataset_slug,
         imported=True,
         changed=changed,
         application_found=True,
+        dealum_name=match.matched_name,
+        dealum_id=match.dealum_id,
+        dealum_url=match.dealum_url,
+        application_code=match.application_code,
+        match_method=match.match_method,
         manifest_path=manifest_path,
         application_path=application_path,
         downloaded_files=downloaded_files,
@@ -186,11 +401,16 @@ def import_startup_from_dealum(
     )
 
 
-def render_application_markdown(application: dict[str, Any]) -> str:
+def render_application_markdown(
+    application: dict[str, Any],
+    *,
+    dealum_url: Optional[str] = None,
+) -> str:
     name = application.get("name") or "Unknown startup"
     lines = [f"# Dealum Application: {name}", ""]
     lines.extend([
         f"- Dealum ID: {application.get('id', '')}",
+        f"- Dealum URL: {dealum_url or ''}",
         f"- Code: {application.get('code', '')}",
         f"- Step: {application.get('step', '')}",
         f"- Tags: {', '.join(application.get('tags') or [])}",

--- a/skills/advocates/advocates.py
+++ b/skills/advocates/advocates.py
@@ -52,15 +52,12 @@ async def advocates(event_name: str, event_description: str, target_members: Opt
     # 2. Call ranking_persons Engine
     logger.info(f"[{event_name_slug}] Invoking ranking_persons engine for advocates...")
     
-    clean_targets = [slugify(c) for c in target_members] if target_members else None
-    clean_excludes = [slugify(c) for c in exclude_members] if exclude_members else None
-    
     result = await ranking_persons(
         dataset_name=people_dataset,
         objective=objective,
         query=event_description,
-        candidates=clean_targets,
-        optout=clean_excludes,
+        candidates=target_members,
+        optout=exclude_members,
         top_k=top_k
     )
     

--- a/skills/dealum_import/SKILL.md
+++ b/skills/dealum_import/SKILL.md
@@ -1,7 +1,9 @@
 # Dealum Import
 
 Use this skill to import a startup application and linked Dealum documents into
-the normal SICTIC-AI startup dataset folder.
+the normal SICTIC-AI startup dataset folder. Startup names are reconciled using
+an exact normalized Dealum name or an exact application code. If neither
+matches, ask the user for the name shown in Dealum.
 
 ## Usage
 

--- a/skills/dealum_import/__main__.py
+++ b/skills/dealum_import/__main__.py
@@ -2,6 +2,7 @@ import asyncio
 
 import typer
 
+from lib.dealum_import import DealumReconciliationError
 from skills.dealum_import.dealum_import import dealum_import
 
 app = typer.Typer(help="Import a startup application and linked documents from Dealum.")
@@ -17,6 +18,10 @@ def main(startup: str):
     for name in startups:
         try:
             result = asyncio.run(dealum_import(name))
+        except DealumReconciliationError as error:
+            typer.echo(f"Could not reconcile {name}: {error}", err=True)
+            failed = True
+            continue
         except Exception as error:
             typer.echo(f"Failed to import {name}: {error}", err=True)
             failed = True
@@ -36,6 +41,8 @@ def main(startup: str):
             typer.echo(f"APPLICATION_PATH: {result.application_path}")
         if result.manifest_path:
             typer.echo(f"MANIFEST_PATH: {result.manifest_path}")
+        if result.dealum_url:
+            typer.echo(f"DEALUM_URL: {result.dealum_url}")
 
     if failed:
         raise typer.Exit(code=1)

--- a/skills/expert_search/expert_search.py
+++ b/skills/expert_search/expert_search.py
@@ -65,16 +65,12 @@ async def expert_search(startup_name: str, target_experts: Optional[List[str]] =
     # 3. Call ranking_persons Engine
     logger.info(f"[{startup_slug}] Invoking ranking_persons engine for expert search...")
     
-    # Ensure candidates and optouts are strictly slugified before passing down
-    clean_targets = [slugify(c) for c in target_experts] if target_experts else None
-    clean_excludes = [slugify(c) for c in exclude_experts] if exclude_experts else None
-    
     result = await ranking_persons(
         dataset_name=people_dataset,
         objective=objective,
         query=profile_content,
-        candidates=clean_targets,
-        optout=clean_excludes,
+        candidates=target_experts,
+        optout=exclude_experts,
         top_k=top_k
     )
     

--- a/skills/potential_investors/potential_investors.py
+++ b/skills/potential_investors/potential_investors.py
@@ -65,15 +65,12 @@ async def potential_investors(startup_name: str, target_investors: Optional[List
     # 3. Call ranking_persons Engine
     logger.info(f"[{startup_slug}] Invoking ranking_persons engine for potential investors...")
     
-    clean_targets = [slugify(c) for c in target_investors] if target_investors else None
-    clean_excludes = [slugify(c) for c in exclude_investors] if exclude_investors else None
-    
     result = await ranking_persons(
         dataset_name=people_dataset,
         objective=objective,
         query=profile_content,
-        candidates=clean_targets,
-        optout=clean_excludes,
+        candidates=target_investors,
+        optout=exclude_investors,
         top_k=top_k
     )
     

--- a/skills/ranking/SKILL.md
+++ b/skills/ranking/SKILL.md
@@ -1,5 +1,9 @@
 # Skill: Ranking
 
+`ranking_persons(...)` returns the human-readable Markdown report.
+`rank_person_rows(...)` returns structured rows for composing other workflows
+without parsing Markdown.
+
 **Description:**
 Core engine to rank entities (like SICTIC members) against a specific objective using an LLM-powered Swiss tournament algorithm. It acts as the unified backend for skills like `expert_search` and `potential_investors`.
 

--- a/skills/ranking/__init__.py
+++ b/skills/ranking/__init__.py
@@ -1,1 +1,1 @@
-from .ranking_persons import ranking_persons
+from .ranking_persons import rank_person_rows, ranking_persons, render_person_ranking

--- a/skills/ranking/ranking_persons.py
+++ b/skills/ranking/ranking_persons.py
@@ -1,204 +1,248 @@
-from typing import List, Optional
+from pathlib import PurePosixPath
+from typing import Any, List, Optional
 
+from lib.insight_refresh import get_base_name
 from lib.logger import get_logger
-from lib.storage import get_storage
+from lib.models.person import Person, normalize_email_addresses
+from lib.slugify import slugify
 from skills.dataset_chat.dataset_search import dataset_search
+from skills.person_profile.persons_in_dataset import persons_in_dataset
 from skills.ranking.ranking_rationale import ranking_rationale
 from skills.ranking.ranking_top_k import ranking_top_k
 
-from rapidfuzz import process, fuzz
-
-from lib.slugify import slugify
-from lib.storage_domains import dataset_raw_path
-from lib.models.person import normalize_email_addresses
-
 logger = get_logger(__name__)
 
-# ==========================================
-# HELPER FUNCTIONS (Single Responsibility)
-# ==========================================
 
-def _resolve_candidates(dataset_name: str, candidates: Optional[List[str]], optout: Optional[List[str]]) -> List[str]:
-    """Determines the final list of candidates to rank by fuzzy-matching against available profiles."""
-    dataset_dir_rel = dataset_raw_path(dataset_name)
-    storage = get_storage()
-    available_profiles = []
-    
-    # Files look like "urs-gubser-gemma4-31b-nvfp4.md"
-    for filename in storage.list(dataset_dir_rel, suffix=".md"):
-        available_profiles.append(filename)
+def _person_reference(value: str, members: List[Person]) -> Person:
+    value = value.strip()
+    emails = normalize_email_addresses(value)
+    if emails:
+        return Person(email_addresses=emails)
 
-    if not available_profiles:
-        raise RuntimeError(f"No profile files found in {dataset_dir_rel}. Cannot rank candidates.")
-        
-    final_candidates = []
-    
+    normalized = slugify(value)
+    exact_linkedin = next(
+        (member for member in members if member.linkedin_id == normalized),
+        None,
+    )
+    if exact_linkedin:
+        return Person(linkedin_id=normalized)
+    return Person(full_name=value)
+
+
+def _resolve_person(
+    value: str,
+    members: List[Person],
+    *,
+    threshold: int = 85,
+) -> Optional[Person]:
+    reference = _person_reference(value, members)
+    return reference.find_best_match(members, threshold=threshold)
+
+
+def _resolve_members(
+    members: List[Person],
+    candidates: Optional[List[str]],
+    optout: Optional[List[str]],
+) -> List[Person]:
     if candidates:
+        selected: List[Person] = []
         missing_candidates = []
-        for c in candidates:
-            c_slug = slugify(c)
-            # Use partial_ratio because c_slug ("urs-gubser") is a substring of the filename ("urs-gubser-gemma4.md")
-            match = process.extractOne(c_slug, available_profiles, scorer=fuzz.partial_ratio)
-            if match and match[1] >= 90:
-                final_candidates.append(match[0])
-            else:
-                missing_candidates.append(c)
-                
+        for value in candidates:
+            matched = _resolve_person(value, members)
+            if matched is None:
+                missing_candidates.append(value)
+            elif matched not in selected:
+                selected.append(matched)
+
         if missing_candidates:
-            err_msg = f"The following requested candidates could not be found in the dataset: {', '.join(missing_candidates)}"
-            logger.error(err_msg)
-            raise ValueError(err_msg)
+            message = (
+                "The following requested candidates could not be matched to "
+                f"sictic-members: {', '.join(missing_candidates)}"
+            )
+            logger.error(message)
+            raise ValueError(message)
     else:
-        final_candidates = available_profiles.copy()
-        
+        selected = list(members)
+
     if optout:
+        excluded_identifiers = set()
         missing_optouts = []
-        optout_matches = set()
-        for o in optout:
-            o_slug = slugify(o)
-            match = process.extractOne(o_slug, available_profiles, scorer=fuzz.partial_ratio)
-            if match and match[1] >= 90:
-                optout_matches.add(match[0])
+        for value in optout:
+            matched = _resolve_person(value, members)
+            if matched is None:
+                missing_optouts.append(value)
             else:
-                missing_optouts.append(o)
-                
+                excluded_identifiers.add(matched.identifier)
+
         if missing_optouts:
-            logger.warning(f"The following optout candidates could not be found in the dataset: {', '.join(missing_optouts)}")
-            
-        final_candidates = [c for c in final_candidates if c not in optout_matches]
-        
-    return list(set(final_candidates))
+            logger.warning(
+                "The following opt-outs could not be matched to sictic-members: %s",
+                ", ".join(missing_optouts),
+            )
+        selected = [
+            person for person in selected
+            if person.identifier not in excluded_identifiers
+        ]
+
+    return selected
 
 
 def _markdown_table_cell(value: str) -> str:
     return value.replace("|", "\\|").replace("\n", " ").strip()
 
 
-def _extract_person_metadata(profile_id: str, text: str) -> dict:
-    metadata = {
-        "full_name": "",
-        "linkedin_id": "",
-        "email_addresses": [],
-    }
-
-    for line in text.splitlines():
-        key, _, value = line.partition(":")
-        normalized_key = key.strip().lower()
-        if normalized_key == "full-name":
-            metadata["full_name"] = value.strip()
-        elif normalized_key == "linkedin-id":
-            metadata["linkedin_id"] = value.strip().lower()
-        elif normalized_key == "email-addresses":
-            metadata["email_addresses"] = normalize_email_addresses(value)
-
-    if not metadata["linkedin_id"]:
-        metadata["linkedin_id"] = slugify(profile_id)
-    if not metadata["full_name"]:
-        metadata["full_name"] = metadata["linkedin_id"]
-
-    return metadata
-
-# ==========================================
-# MAIN ORCHESTRATOR
-# ==========================================
-
-async def ranking_persons(
-    dataset_name: str = "person_profile",
-    objective: str = "", 
-    query: str = "",
-    candidates: Optional[List[str]] = None, 
-    optout: Optional[List[str]] = None, 
-    top_k: int = 8
-) -> str:
-    """
-    Core engine to rank SICTIC members using pairwise comparisons.
-    Returns the generated markdown report as a string.
-    """
-    logger.info("Starting ranking_persons")
-    
-    # Ensure dataset name is safely slugified before traversing storage
-    dataset_name = slugify(dataset_name)
-
-    # 1. Resolve Candidates
-    final_candidates = _resolve_candidates(dataset_name, candidates, optout)
-
-    # 2. Semantic Search & Filtering
-    cutoff_m = top_k * 8
-    logger.info(f"Starting semantic search on dataset '{dataset_name}' with query: '{query[:50]}...'")
-    chunks = await dataset_search(
-        dataset_name=dataset_name, 
-        query=query, 
-        max_chunks=cutoff_m * 20
-    )
-    
-    if not chunks:
-        err_msg = f"No documents found in dataset {dataset_name} during semantic search."
-        logger.error(err_msg)
-        raise RuntimeError(err_msg)
-
-    id_to_text = {}
-    metadata_by_id = {}
-    
-    # Filter chunks based on the resolved candidates list
-    for c in chunks:
-        doc_name = c.document_name
-            
-        if doc_name in final_candidates:
-            metadata = _extract_person_metadata(doc_name, c.text)
-            person_id = metadata["linkedin_id"]
-            if person_id not in id_to_text:
-                id_to_text[person_id] = ""
-                metadata_by_id[person_id] = metadata
-            # Aggregate the chunks cleanly into the person's text block
-            id_to_text[person_id] += c.to_md() + "\n\n"
-            if len(id_to_text) >= cutoff_m:
-                break
-                
-    if not id_to_text:
-        err_msg = "No documents remained after filtering semantic search results against the candidate list."
-        logger.error(err_msg)
-        raise RuntimeError(err_msg)
-
-    # 3. Execute Find Top K
-    logger.info(f"Starting ranking_top_k with {len(id_to_text)} candidates (target top_k: {top_k}).")
-    ranked_items, actual_top_k = await ranking_top_k(
-        objective=objective,
-        all_profiles=id_to_text,
-        top_k=top_k
-    )
-
-    for item in ranked_items:
-        item.update(metadata_by_id.get(item["id"], {}))
-
-    # 4. Synthesize Final Rationales
-    logger.info(f"Starting ranking_rationale with top {actual_top_k} out of {len(ranked_items)} ranked candidates.")
-    augmented_items = await ranking_rationale(
-        ranked_items=ranked_items,
-        objective=objective
-    )
-
-    # 5. Build Markdown Table
+def render_person_ranking(rows: List[dict[str, Any]]) -> str:
     lines = [
         "## Top Candidates",
         "",
-        "| Rank | Full Name | LinkedIn ID | Email Addresses | Ranking Rationale |",
-        "| :--- | :--- | :--- | :--- | :--- |"
+        "| Rank | Full Name | Email Addresses | LinkedIn ID | Rationale |",
+        "| :--- | :--- | :--- | :--- | :--- |",
     ]
-    
-    for item in augmented_items:
-        full_name = item.get("full_name") or item["id"]
-        linkedin_id = item.get("linkedin_id") or item["id"]
-        email_addresses = ", ".join(item.get("email_addresses") or [])
-        clean_rationale = item.get("rationale", "").replace("\n", " ")
+    for row in rows:
         lines.append(
-            f"| {item.get('rank', '-')} | "
-            f"{_markdown_table_cell(full_name)} | "
-            f"{_markdown_table_cell(linkedin_id)} | "
-            f"{_markdown_table_cell(email_addresses)} | "
-            f"{_markdown_table_cell(clean_rationale)} |"
+            f"| {row['rank']} | "
+            f"{_markdown_table_cell(row['full_name'])} | "
+            f"{_markdown_table_cell(', '.join(row['email_addresses']))} | "
+            f"{_markdown_table_cell(row['linkedin_id'])} | "
+            f"{_markdown_table_cell(row['rationale'])} |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+async def rank_person_rows(
+    dataset_name: str = "sictic-members-investor-profile",
+    objective: str = "",
+    query: str = "",
+    candidates: Optional[List[str]] = None,
+    optout: Optional[List[str]] = None,
+    top_k: int = 8,
+    member_dataset: str = "sictic-members",
+) -> List[dict[str, Any]]:
+    """Rank member profiles and return structured rows."""
+    dataset_name = slugify(dataset_name)
+    members = persons_in_dataset(member_dataset)
+    if not members:
+        raise RuntimeError(f"No persons found in member dataset '{member_dataset}'.")
+
+    selected_members = _resolve_members(members, candidates, optout)
+    members_by_linkedin = {
+        person.linkedin_id: person
+        for person in selected_members
+        if person.linkedin_id
+    }
+    skipped_without_linkedin = [
+        person.display_name
+        for person in selected_members
+        if not person.linkedin_id
+    ]
+    if skipped_without_linkedin:
+        logger.warning(
+            "Skipping %d selected members without LinkedIn IDs: %s",
+            len(skipped_without_linkedin),
+            ", ".join(skipped_without_linkedin),
+        )
+    if not members_by_linkedin:
+        raise RuntimeError("No selected members have LinkedIn IDs for profile ranking.")
+
+    cutoff_m = top_k * 8
+    logger.info(
+        "Starting semantic search on dataset '%s' across %d selected members.",
+        dataset_name,
+        len(members_by_linkedin),
+    )
+    chunks = await dataset_search(
+        dataset_name=dataset_name,
+        query=query,
+        max_chunks=cutoff_m * 20,
+    )
+    if not chunks:
+        raise RuntimeError(
+            f"No documents found in dataset {dataset_name} during semantic search."
         )
 
-    result = "\n".join(lines) + "\n"
+    profile_text_by_id: dict[str, str] = {}
+    for chunk in chunks:
+        filename = PurePosixPath(chunk.document_name).name
+        linkedin_id = get_base_name(filename)
+        if linkedin_id not in members_by_linkedin:
+            continue
+        profile_text_by_id.setdefault(linkedin_id, "")
+        profile_text_by_id[linkedin_id] += chunk.to_md() + "\n\n"
+        if len(profile_text_by_id) >= cutoff_m:
+            break
 
-    logger.info(f"[{dataset_name}] ranking_persons complete.")
+    if not profile_text_by_id:
+        raise RuntimeError(
+            "No profile documents remained after matching search results to "
+            "the selected sictic-members roster."
+        )
+
+    if candidates:
+        missing_profiles = [
+            person.display_name
+            for person in selected_members
+            if person.linkedin_id not in profile_text_by_id
+        ]
+        if missing_profiles:
+            raise ValueError(
+                "The following requested candidates have no searchable profile: "
+                + ", ".join(missing_profiles)
+            )
+
+    logger.info(
+        "Starting ranking_top_k with %d candidates (target top_k: %d).",
+        len(profile_text_by_id),
+        top_k,
+    )
+    ranked_items, actual_top_k = await ranking_top_k(
+        objective=objective,
+        all_profiles=profile_text_by_id,
+        top_k=top_k,
+    )
+    logger.info(
+        "Starting ranking_rationale with top %d out of %d ranked candidates.",
+        actual_top_k,
+        len(ranked_items),
+    )
+    augmented_items = await ranking_rationale(
+        ranked_items=ranked_items,
+        objective=objective,
+    )
+
+    rows = []
+    for item in augmented_items:
+        person = members_by_linkedin[item["id"]]
+        rows.append(
+            {
+                "rank": item.get("rank", len(rows) + 1),
+                "full_name": person.display_name,
+                "email_addresses": list(person.email_addresses),
+                "linkedin_id": person.linkedin_id,
+                "rationale": item.get("rationale", ""),
+            }
+        )
+    return rows
+
+
+async def ranking_persons(
+    dataset_name: str = "sictic-members-investor-profile",
+    objective: str = "",
+    query: str = "",
+    candidates: Optional[List[str]] = None,
+    optout: Optional[List[str]] = None,
+    top_k: int = 8,
+    member_dataset: str = "sictic-members",
+) -> str:
+    """Rank member profiles and return a Markdown report."""
+    rows = await rank_person_rows(
+        dataset_name=dataset_name,
+        objective=objective,
+        query=query,
+        candidates=candidates,
+        optout=optout,
+        top_k=top_k,
+        member_dataset=member_dataset,
+    )
+    result = render_person_ranking(rows)
+    logger.info("[%s] ranking_persons complete.", slugify(dataset_name))
     return result

--- a/tests/cli/test_dealum_import_cli.py
+++ b/tests/cli/test_dealum_import_cli.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 
 from typer.testing import CliRunner
+from lib.dealum_import import DealumApplicationNotFoundError
 
 
 def _result(name: str, *, found: bool = True):
@@ -12,6 +13,7 @@ def _result(name: str, *, found: bool = True):
         downloaded_files=2,
         skipped_files=0,
         step="Jury",
+        dealum_url=f"https://app.dealum.com/#/dealroom/19180?application={slug}",
         application_path=f"storage/startups/{slug}/datasets/dealum/application.md",
         manifest_path=f"storage/startups/{slug}/datasets/dealum/manifest.json",
     )
@@ -38,6 +40,7 @@ def test_dealum_import_cli_imports_comma_separated_startups(mocker):
     assert "Imported avientus" in result.output
     assert "Imported daav" in result.output
     assert "Imported prevision-medicine" in result.output
+    assert "DEALUM_URL: https://app.dealum.com/#/dealroom/19180?application=avientus" in result.output
 
 
 def test_dealum_import_cli_continues_after_missing_application(mocker):
@@ -59,4 +62,30 @@ def test_dealum_import_cli_continues_after_missing_application(mocker):
     assert result.exit_code == 1
     assert imported == ["Avientus", "missing", "daav"]
     assert "No Dealum application found for missing." in result.output
+    assert "Imported daav" in result.output
+
+
+def test_dealum_import_cli_reports_reconciliation_failure_and_continues(mocker):
+    from skills.dealum_import.__main__ import app
+
+    imported = []
+
+    async def fake_dealum_import(name):
+        imported.append(name)
+        if name == "novov":
+            raise DealumApplicationNotFoundError(
+                "No exact Dealum application match for 'novov'."
+            )
+        return _result(name)
+
+    mocker.patch(
+        "skills.dealum_import.__main__.dealum_import",
+        side_effect=fake_dealum_import,
+    )
+
+    result = CliRunner().invoke(app, ["Avientus, novov, daav"])
+
+    assert result.exit_code == 1
+    assert imported == ["Avientus", "novov", "daav"]
+    assert "Could not reconcile novov" in result.output
     assert "Imported daav" in result.output

--- a/tests/ranking/test_ranking_persons.py
+++ b/tests/ranking/test_ranking_persons.py
@@ -1,14 +1,48 @@
 import pytest
 
+from lib.models.person import Person
 from skills.dataset_chat.core.models import Chunk
-from skills.ranking.ranking_persons import ranking_persons
+from skills.ranking.ranking_persons import (
+    _resolve_members,
+    rank_person_rows,
+    ranking_persons,
+)
+
+
+MEMBERS = [
+    Person(
+        full_name="Urs Gubser",
+        linkedin_id="urs-gubser",
+        email_addresses=["urs@gubser.ch", "urs.gubser@investor.sictic.ch"],
+    ),
+    Person(
+        full_name="Jane Doe",
+        linkedin_id="jane-doe",
+        email_addresses=["jane@sictic.ch"],
+    ),
+]
+
+
+def test_resolve_members_uses_person_matching_for_candidates_and_optouts():
+    selected = _resolve_members(
+        MEMBERS,
+        candidates=["urs@gubser.ch", "Jane Doe"],
+        optout=["jane-doe"],
+    )
+
+    assert selected == [MEMBERS[0]]
+
+
+def test_resolve_members_reports_unknown_requested_candidate():
+    with pytest.raises(ValueError, match="Missing Member"):
+        _resolve_members(MEMBERS, candidates=["Missing Member"], optout=None)
 
 
 @pytest.mark.asyncio
-async def test_ranking_persons_uses_person_metadata_for_final_table(mock_env, mocker):
+async def test_rank_person_rows_uses_roster_metadata_and_linkedin_id(mock_env, mocker):
     mocker.patch(
-        "skills.ranking.ranking_persons._resolve_candidates",
-        return_value=["urs-gubser-gemma4-31b-nvfp4.md"],
+        "skills.ranking.ranking_persons.persons_in_dataset",
+        return_value=MEMBERS,
     )
     mocker.patch(
         "skills.ranking.ranking_persons.dataset_search",
@@ -18,15 +52,7 @@ async def test_ranking_persons_uses_person_metadata_for_final_table(mock_env, mo
                 document_name="urs-gubser-gemma4-31b-nvfp4.md",
                 page_number=1,
                 last_modified=0,
-                text="\n".join(
-                    [
-                        "Full-name: Urs Gubser",
-                        "linkedin-id: urs-gubser",
-                        "Email-addresses: urs@gubser.ch, urs.gubser@investor.sictic.ch",
-                        "",
-                        "Profile body",
-                    ]
-                ),
+                text="Profile body without metadata headers",
                 score=1.0,
             )
         ],
@@ -34,13 +60,7 @@ async def test_ranking_persons_uses_person_metadata_for_final_table(mock_env, mo
     mocker.patch(
         "skills.ranking.ranking_persons.ranking_top_k",
         return_value=(
-            [
-                {
-                    "id": "urs-gubser",
-                    "text": "Profile body",
-                    "rank": 1,
-                }
-            ],
+            [{"id": "urs-gubser", "text": "Profile body", "rank": 1}],
             1,
         ),
     )
@@ -49,21 +69,60 @@ async def test_ranking_persons_uses_person_metadata_for_final_table(mock_env, mo
         return_value=[
             {
                 "id": "urs-gubser",
-                "full_name": "Urs Gubser",
-                "linkedin_id": "urs-gubser",
-                "email_addresses": ["urs@gubser.ch", "urs.gubser@investor.sictic.ch"],
+                "text": "Profile body",
                 "rank": 1,
                 "rationale": "Strong fit.",
             }
         ],
     )
 
+    rows = await rank_person_rows(
+        dataset_name="sictic-members-investor-profile",
+        objective="Find experts",
+        query="expert",
+        candidates=["Urs Gubser"],
+        top_k=1,
+    )
+
+    assert rows == [
+        {
+            "rank": 1,
+            "full_name": "Urs Gubser",
+            "email_addresses": [
+                "urs@gubser.ch",
+                "urs.gubser@investor.sictic.ch",
+            ],
+            "linkedin_id": "urs-gubser",
+            "rationale": "Strong fit.",
+        }
+    ]
+@pytest.mark.asyncio
+async def test_ranking_persons_renders_structured_rows_as_markdown(mock_env, mocker):
+    mocker.patch(
+        "skills.ranking.ranking_persons.rank_person_rows",
+        return_value=[
+            {
+                "rank": 1,
+                "full_name": "Urs Gubser",
+                "email_addresses": [
+                    "urs@gubser.ch",
+                    "urs.gubser@investor.sictic.ch",
+                ],
+                "linkedin_id": "urs-gubser",
+                "rationale": "Strong fit.",
+            }
+        ],
+    )
+
     result = await ranking_persons(
-        dataset_name="sictic-members-person-profile",
+        dataset_name="sictic-members-investor-profile",
         objective="Find experts",
         query="expert",
         top_k=1,
     )
 
-    assert "| Rank | Full Name | LinkedIn ID | Email Addresses | Ranking Rationale |" in result
-    assert "| 1 | Urs Gubser | urs-gubser | urs@gubser.ch, urs.gubser@investor.sictic.ch | Strong fit. |" in result
+    assert "| Rank | Full Name | Email Addresses | LinkedIn ID | Rationale |" in result
+    assert (
+        "| 1 | Urs Gubser | urs@gubser.ch, urs.gubser@investor.sictic.ch | "
+        "urs-gubser | Strong fit. |"
+    ) in result

--- a/tests/skills/test_investor_profile_ranking_routes.py
+++ b/tests/skills/test_investor_profile_ranking_routes.py
@@ -79,3 +79,65 @@ async def test_ranking_skill_uses_investor_profile_dataset(
         source_dataset="sictic-members",
     )
     assert ranking.await_args.kwargs["dataset_name"] == "sictic-members-investor-profile"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "module,func_name,args,targets,excludes",
+    [
+        (
+            expert_search_module,
+            "expert_search",
+            ("example-startup",),
+            {"target_experts": ["Urs Gubser"]},
+            {"exclude_experts": ["jane@sictic.ch"]},
+        ),
+        (
+            potential_investors_module,
+            "potential_investors",
+            ("example-startup",),
+            {"target_investors": ["Urs Gubser"]},
+            {"exclude_investors": ["jane@sictic.ch"]},
+        ),
+        (
+            advocates_module,
+            "advocates",
+            ("example-event", "Event description"),
+            {"target_members": ["Urs Gubser"]},
+            {"exclude_members": ["jane@sictic.ch"]},
+        ),
+    ],
+)
+async def test_ranking_skills_pass_person_references_without_slugifying(
+    mock_env,
+    mocker,
+    module,
+    func_name,
+    args,
+    targets,
+    excludes,
+):
+    mocker.patch.object(module, "check_insight_refresh", return_value=(True, None, None))
+    if hasattr(module, "startup_profile"):
+        mocker.patch.object(module, "startup_profile", side_effect=_fake_startup_profile)
+    config_key = func_name
+    mocker.patch.object(
+        module,
+        "config_load",
+        return_value={
+            config_key: {
+                "objective": "Objective {{startup_profile}}{{overview_event}}"
+            }
+        },
+    )
+    mocker.patch.object(module, "dataset_from_insight")
+    ranking = mocker.patch.object(
+        module,
+        "ranking_persons",
+        side_effect=_fake_ranking_persons,
+    )
+
+    await getattr(module, func_name)(*args, **targets, **excludes)
+
+    assert ranking.await_args.kwargs["candidates"] == ["Urs Gubser"]
+    assert ranking.await_args.kwargs["optout"] == ["jane@sictic.ch"]

--- a/tests/utils/test_dealum_import.py
+++ b/tests/utils/test_dealum_import.py
@@ -2,7 +2,12 @@ import json
 
 import pytest
 
-from lib.dealum_import import import_startup_from_dealum
+from lib.dealum_import import (
+    DealumApplicationAmbiguousError,
+    DealumApplicationNotFoundError,
+    import_startup_from_dealum,
+    reconcile_dealum_startup,
+)
 from lib.startup_data_sources import ensure_startup_dataset
 from lib.storage import get_storage
 from lib.storage import LocalStorage
@@ -30,15 +35,17 @@ APPLICATION = {
 
 
 class FakeDealumAdapter:
-    def __init__(self, application=APPLICATION):
+    def __init__(self, application=APPLICATION, applications=None):
         self.application = application
+        self.applications = applications if applications is not None else [application]
+        self.dealroom_id = "19180"
         self.downloads = 0
 
     def is_configured(self):
         return True
 
-    def find_application(self, startup):
-        return self.application
+    def list_applications(self):
+        return self.applications
 
     def extract_file_links(self, application):
         from lib.adapters.dealum import DealumAdapter
@@ -98,6 +105,13 @@ def test_dealum_import_creates_dataset_and_manifest(mock_env):
     assert result.imported is True
     assert result.changed is True
     assert result.dataset_slug == "avientus"
+    assert result.dealum_name == "Avientus"
+    assert result.dealum_id == 491739
+    assert result.dealum_url == (
+        "https://app.dealum.com/#/dealroom/19180?application=491739"
+    )
+    assert result.application_code == "JHXM-QZHJ-8684"
+    assert result.match_method == "normalized_name"
     assert result.downloaded_files == 2
     assert storage.exists("storage/startups/avientus/datasets/dealum/application.md")
     assert storage.exists("storage/startups/avientus/datasets/dealum/documents/Avientus_Deck.pdf")
@@ -105,8 +119,18 @@ def test_dealum_import_creates_dataset_and_manifest(mock_env):
 
     manifest = json.loads(storage.read_text("storage/startups/avientus/datasets/dealum/manifest.json"))
     assert manifest["dealum_id"] == 491739
+    assert manifest["dealum_url"] == (
+        "https://app.dealum.com/#/dealroom/19180?application=491739"
+    )
     assert manifest["step"] == "Jury"
     assert len(manifest["files"]) == 2
+    application_md = storage.read_text(
+        "storage/startups/avientus/datasets/dealum/application.md"
+    )
+    assert (
+        "- Dealum URL: https://app.dealum.com/#/dealroom/19180?application=491739"
+        in application_md
+    )
 
 
 def test_dealum_import_unchanged_skips_rewrite_and_preserves_manual_files(mock_env):
@@ -164,3 +188,73 @@ async def test_ensure_startup_dataset_no_dealum_env_is_noop(mock_env):
     assert status.dealum_configured is False
     assert status.dataset_exists is False
     assert not get_storage().exists(dataset_raw_path("missingco"))
+
+
+def test_reconcile_dealum_startup_matches_normalized_name(mock_env, caplog):
+    novoviz = {
+        **APPLICATION,
+        "id": 991,
+        "name": "NovoViz",
+        "code": "NOVO-991",
+        "step": "Selected for pitching",
+    }
+
+    match = reconcile_dealum_startup(
+        "novoviz",
+        adapter=FakeDealumAdapter(novoviz),
+    )
+
+    assert match.matched_name == "NovoViz"
+    assert match.dataset_slug == "novoviz"
+    assert match.dealum_url == (
+        "https://app.dealum.com/#/dealroom/19180?application=991"
+    )
+    assert match.match_method == "normalized_name"
+    assert match.step == "Selected for pitching"
+    assert "Matched requested='novoviz' to name='NovoViz'" in caplog.text
+
+
+def test_reconcile_dealum_startup_matches_exact_application_code(mock_env):
+    novoviz = {
+        **APPLICATION,
+        "id": 991,
+        "name": "NovoViz",
+        "code": "NOVO-991",
+    }
+
+    match = reconcile_dealum_startup(
+        " novo-991 ",
+        adapter=FakeDealumAdapter(novoviz),
+    )
+
+    assert match.matched_name == "NovoViz"
+    assert match.match_method == "application_code"
+
+
+def test_reconcile_dealum_startup_rejects_substring_match(mock_env):
+    novoviz = {
+        **APPLICATION,
+        "name": "NovoViz Medical Imaging",
+        "code": "NOVO-991",
+    }
+
+    with pytest.raises(DealumApplicationNotFoundError, match="No exact Dealum application match"):
+        reconcile_dealum_startup(
+            "novoviz",
+            adapter=FakeDealumAdapter(novoviz),
+        )
+
+
+def test_reconcile_dealum_startup_rejects_ambiguous_exact_name(mock_env, caplog):
+    applications = [
+        {**APPLICATION, "id": 1, "name": "NovoViz", "code": "NOVO-1"},
+        {**APPLICATION, "id": 2, "name": "novoviz", "code": "NOVO-2"},
+    ]
+
+    with pytest.raises(DealumApplicationAmbiguousError, match="Multiple Dealum applications"):
+        reconcile_dealum_startup(
+            "novoviz",
+            adapter=FakeDealumAdapter(applications=applications),
+        )
+
+    assert "Ambiguous exact match" in caplog.text


### PR DESCRIPTION
## What changed

- Made Dealum startup reconciliation and dossier imports more robust, including canonical application URLs.
- Updated `expert_search`, `potential_investors`, and `advocates` to rank the `sictic-members` roster using the `Person` class.
- Added structured ranking rows with full name, email addresses, LinkedIn ID, and rationale.
- Added focused tests for Dealum reconciliation, CLI imports, investor-profile routing, and person ranking.
- Updated the startup-profile prompt to begin with the startup name.

## Why

This prepares the deep-dive workflow to reconcile startups reliably and identify relevant SICTIC experts and investors from consistent person records.

## Known limitation

The final expert-search flow is awaiting the planned storage-location upgrade. Dynamically generated derived datasets currently lose their storage-domain context during ingestion/search; this PR intentionally does not add another domain-routing workaround.

## Validation

The implementation state passed the full test suite before the temporary storage experiment: `163 passed, 5 skipped`. The temporary storage-domain patch was then removed. A final focused rerun was not performed.