### PR TITLE
[codex] Final Drive sync and ranking fixes

### DIFF
--- a/lib/datasets/search.py
+++ b/lib/datasets/search.py
@@ -14,6 +14,7 @@ async def dataset_search(
     dataset_name: str,
     query: str | list[str] = "",
     max_chunks: int = 25,
+    raise_on_error: bool = False,
 ) -> list[Chunk]:
     """Unified API to run semantic search and retrieve dataset chunks."""
     dataset_slug = slugify(dataset_name)
@@ -37,7 +38,11 @@ async def dataset_search(
             for vector in vectors
         ]
     except Exception as exc:
-        logger.error("Semantic search failed: %s", exc)
+        logger.exception("Semantic search failed for dataset '%s'.", dataset_slug)
+        if raise_on_error:
+            raise RuntimeError(
+                f"Semantic search failed for dataset '{dataset_slug}': {exc}"
+            ) from exc
         return []
 
     chunks = []

--- a/skills/advocates/SKILL.md
+++ b/skills/advocates/SKILL.md
@@ -5,6 +5,14 @@ description: Shortlists 10 members that can represent SICTIC at an event; rangin
 
 ## Usage
 
+Via the slash-command harness:
+
 ```bash
 conda run -n sictic-env python -m skills.harness /advocates "<EVENT_NAME>" --description "<EVENT_DESCRIPTION>"
+```
+
+Via the direct Typer entrypoint:
+
+```bash
+conda run -n sictic-env python -m skills.advocates --event "<EVENT_NAME>" --description "<EVENT_DESCRIPTION>"
 ```

--- a/skills/gdrive_sync/changes.py
+++ b/skills/gdrive_sync/changes.py
@@ -162,6 +162,21 @@ def _is_self_generated_change(
     return bool(path and path in mutations.paths)
 
 
+def _sleep_with_countdown(wait_seconds: float) -> None:
+    full_seconds = int(wait_seconds)
+    if full_seconds <= 0:
+        time.sleep(wait_seconds)
+        return
+
+    for remaining in range(full_seconds, 0, -1):
+        logger.info("Drive quiet wait countdown: %s", remaining)
+        time.sleep(1.0)
+
+    remainder = wait_seconds - full_seconds
+    if remainder > 0:
+        time.sleep(remainder)
+
+
 def wait_for_drive_quiet(
     context,
     *,
@@ -175,7 +190,7 @@ def wait_for_drive_quiet(
     token = start_token
     while True:
         if wait_seconds > 0:
-            time.sleep(wait_seconds)
+            _sleep_with_countdown(wait_seconds)
         result.quiet_wait_rounds += 1
         changes, next_token = context.drive.list_changes(token)
         if not changes:

--- a/skills/ranking/ranking_persons.py
+++ b/skills/ranking/ranking_persons.py
@@ -154,6 +154,7 @@ async def rank_person_rows(
         dataset_name=dataset_name,
         query=query,
         max_chunks=cutoff_m * 20,
+        raise_on_error=True,
     )
     if not chunks:
         raise RuntimeError(

--- a/tests/dataset_chat/test_dataset_search.py
+++ b/tests/dataset_chat/test_dataset_search.py
@@ -60,6 +60,28 @@ async def test_dataset_search_normalizes_ids_from_legacy_and_current_payloads(mo
     assert chunks[0].score == 0.91
 
 
+@pytest.mark.asyncio
+async def test_dataset_search_can_raise_after_logging_failures(mocker):
+    mocker.patch("lib.datasets.search.sync_datasets")
+    embedding_service = mocker.patch(
+        "lib.datasets.search.EmbeddingService"
+    )
+    embedding_service.return_value.embed_many = mocker.AsyncMock(
+        side_effect=RuntimeError("embedding service unavailable")
+    )
+    logged = mocker.patch("lib.datasets.search.logger.exception")
+
+    with pytest.raises(RuntimeError, match="Semantic search failed"):
+        await dataset_search(
+            "Avientus",
+            "profile query",
+            max_chunks=25,
+            raise_on_error=True,
+        )
+
+    logged.assert_called_once()
+
+
 def test_parsed_filepath_keeps_markdown_source_name():
     assert parsed_filepath("docling_data/datasets2md/generated/person-profile/datasets", "urs-gubser.md") == (
         "docling_data/datasets2md/generated/person-profile/datasets/urs-gubser.md"

--- a/tests/gdrive_sync/test_changes.py
+++ b/tests/gdrive_sync/test_changes.py
@@ -1,0 +1,21 @@
+import logging
+
+from skills.gdrive_sync.changes import _sleep_with_countdown
+
+
+def test_sleep_with_countdown_logs_each_full_second(monkeypatch, caplog):
+    sleeps = []
+    monkeypatch.setattr("skills.gdrive_sync.changes.time.sleep", sleeps.append)
+    caplog.set_level(logging.INFO, logger="skills.gdrive_sync.changes")
+
+    _sleep_with_countdown(3.25)
+
+    assert sleeps == [1.0, 1.0, 1.0, 0.25]
+    assert [
+        record.getMessage()
+        for record in caplog.records
+    ] == [
+        "Drive quiet wait countdown: 3",
+        "Drive quiet wait countdown: 2",
+        "Drive quiet wait countdown: 1",
+    ]


### PR DESCRIPTION
## Summary
- add per-second countdown logging during the final gdrive_sync quiet wait
- make ranking fail loudly when semantic search fails instead of silently ranking an empty candidate set
- document the direct Typer entrypoint for the advocates skill

## Validation
- python -m pytest tests/gdrive_sync
- python -m pytest tests/dataset_chat/test_dataset_search.py tests/ranking/test_ranking_persons.py tests/skills/test_investor_profile_ranking_routes.py
- python -m py_compile lib/datasets/search.py skills/ranking/ranking_persons.py