### PR TITLE
Clean up legacy environment variables

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -29,10 +29,6 @@ RANKED_LLMS="gemini3.1-pro-preview, gemini-3.1-flash-lite, gemma4:31b-nvfp4, qwe
 QDRANT_HOST=http://localhost:6333
 OLLAMA_HOST=http://localhost:11434
 
-# Storage Configuration
-# Temporary selector retained for compatibility; planned for removal.
-STORAGE_PROVIDER=local
-
 # Absolute local application storage path.
 LOCAL_STORAGE_PATH=
 

--- a/README.md
+++ b/README.md
@@ -152,6 +152,12 @@ configure these variables:
 
 *(Note: The other variables in `.env-template` are explained inline. You don't need to change them).*
 
+`REPO_PATH` points to this git repository. `WORKSPACE_PATH` points to the
+installed skill-copy directory used by the AI workspace for skill discovery.
+Legacy aliases such as `REPO_DIR`, `WORKSPACE_DIR`, `STORAGE_PROVIDER`,
+`STORAGE_PATH`, and `STORAGE_MIRROR_PATH` are no longer used; the installer
+removes them from `.env` when it runs.
+
 ### Step 4: Start Background Services
 
 SICTIC-AI relies on Qdrant for semantic search and on Ollama when any configured

--- a/install.sh
+++ b/install.sh
@@ -365,6 +365,56 @@ env_set() {
     mv "$tmp" "$ENV_PATH"
 }
 
+env_has() {
+    key="$1"
+    if [ ! -f "$ENV_PATH" ]; then
+        return 1
+    fi
+    grep -q "^[[:space:]]*$key[[:space:]]*=" "$ENV_PATH"
+}
+
+env_unset() {
+    key="$1"
+    if [ ! -f "$ENV_PATH" ]; then
+        return
+    fi
+    tmp="$ENV_PATH.tmp.$$"
+    awk -F= -v k="$key" '
+        $0 ~ "^[[:space:]]*" k "[[:space:]]*=" { next }
+        { print }
+    ' "$ENV_PATH" > "$tmp"
+    mv "$tmp" "$ENV_PATH"
+}
+
+prune_legacy_env_vars() {
+    removed=""
+    for key in \
+        DEFAULT_LLM \
+        DEFAULT_EMBEDDINGS \
+        DEFAULT_VLM \
+        MAX_CONCURRENT_DOCLING \
+        MAX_CONCURRENT_EMBEDS \
+        MAX_CONCURRENT_LLMS \
+        OLLAMA_NUM_CTX \
+        OLLAMA_NUM_CTX_MAX \
+        REPO_DIR \
+        WORKSPACE_DIR \
+        STORAGE_MIRROR_DIR \
+        STORAGE_MIRROR_PATH \
+        STORAGE_PATH \
+        STORAGE_PROVIDER \
+        SICTIC_SYNC_DAEMON
+    do
+        if env_has "$key"; then
+            env_unset "$key"
+            removed="$removed $key"
+        fi
+    done
+    if [ -n "$removed" ]; then
+        echo "Removed legacy .env variables:$removed"
+    fi
+}
+
 ask_env() {
     key="$1"
     prompt="$2"
@@ -408,6 +458,8 @@ if [ ! -f "$ENV_PATH" ]; then
 else
     echo "[4/4] Updating $ENV_PATH"
 fi
+
+prune_legacy_env_vars
 
 if [ "$INTERACTIVE" -eq 1 ]; then
     echo

--- a/tests/test_env_template.py
+++ b/tests/test_env_template.py
@@ -1,0 +1,28 @@
+import re
+from pathlib import Path
+
+
+def test_env_template_excludes_legacy_variables():
+    template = Path(__file__).resolve().parents[1] / ".env-template"
+    content = template.read_text(encoding="utf-8")
+
+    legacy_keys = {
+        "DEFAULT_LLM",
+        "DEFAULT_EMBEDDINGS",
+        "DEFAULT_VLM",
+        "MAX_CONCURRENT_DOCLING",
+        "MAX_CONCURRENT_EMBEDS",
+        "MAX_CONCURRENT_LLMS",
+        "OLLAMA_NUM_CTX",
+        "OLLAMA_NUM_CTX_MAX",
+        "REPO_DIR",
+        "WORKSPACE_DIR",
+        "STORAGE_MIRROR_DIR",
+        "STORAGE_MIRROR_PATH",
+        "STORAGE_PATH",
+        "STORAGE_PROVIDER",
+        "SICTIC_SYNC_DAEMON",
+    }
+
+    for key in legacy_keys:
+        assert not re.search(rf"^\s*{key}\s*=", content, re.MULTILINE)

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -31,6 +31,18 @@ def test_install_script_copies_skills_and_sets_env(tmp_path):
         "CLOUD_STORAGE_PATH=\n",
         encoding="utf-8",
     )
+    (source / ".env").write_text(
+        "REPO_PATH=\n"
+        "WORKSPACE_PATH=\n"
+        "LOCAL_STORAGE_PATH=\n"
+        "LOCAL_DATA_PATH=\n"
+        "CLOUD_PROVIDER=google\n"
+        "CLOUD_STORAGE_PATH=\n"
+        "STORAGE_PROVIDER=google\n"
+        "DEFAULT_LLM=legacy\n"
+        "OLLAMA_NUM_CTX=4096\n",
+        encoding="utf-8",
+    )
 
     fake_bin = tmp_path / "bin"
     fake_bin.mkdir()
@@ -85,4 +97,6 @@ def test_install_script_copies_skills_and_sets_env(tmp_path):
     assert f"WORKSPACE_PATH={target}" in env_file
     assert f"LOCAL_STORAGE_PATH={source / '.storage'}" in env_file
     assert f"LOCAL_DATA_PATH={source}" in env_file
-
+    assert "STORAGE_PROVIDER=" not in env_file
+    assert "DEFAULT_LLM=" not in env_file
+    assert "OLLAMA_NUM_CTX=" not in env_file


### PR DESCRIPTION
## Summary
- remove legacy STORAGE_PROVIDER from .env-template
- prune unused legacy .env keys during install
- document REPO_PATH vs WORKSPACE_PATH and legacy aliases
- add tests for template exclusions and installer pruning

## Tests
- conda run -n sictic-env pytest tests/test_install_script.py tests/test_env_template.py tests/utils/test_storage_configuration.py tests/utils/test_model_config.py