### PR TITLE
Add deterministic skill harness coverage

### DIFF
--- a/skills/standards_and_architecture/__init__.py
+++ b/skills/standards_and_architecture/__init__.py
@@ -1,0 +1,1 @@
+"""Standards and architecture skill package."""

--- a/tests/skill_harness/__init__.py
+++ b/tests/skill_harness/__init__.py
@@ -1,0 +1,1 @@
+"""Skill harness test helpers."""

--- a/tests/skill_harness/cases.py
+++ b/tests/skill_harness/cases.py
@@ -1,0 +1,59 @@
+ADMIN_ONLY_HARNESS_COMMANDS = {
+    "/config",
+    "/sync",
+    "/dealum_import",
+}
+
+SKILL_COVERAGE = {
+    "advocates": "local-smoke",
+    "batch_audit": "local-smoke",
+    "bulk_refresh": "existing-unit",
+    "config_load": "existing-unit",
+    "dataset_chat": "harness-smoke",
+    "dataset_maintenance": "utility-smoke",
+    "dd_checks": "local-smoke",
+    "dealum_import": "utility-smoke",
+    "expert_search": "local-smoke",
+    "gdrive_sync": "contract-admin",
+    "harness": "existing-unit",
+    "investor_profile": "local-smoke",
+    "linkedin_maintenance": "utility-smoke",
+    "llm_chat": "utility-smoke",
+    "person_profile": "local-smoke",
+    "potential_investors": "local-smoke",
+    "ranking": "utility-smoke",
+    "sictic_git_sync": "existing-unit",
+    "standards_and_architecture": "docs-only",
+    "startup_profile": "local-smoke",
+    "startup_traction": "local-smoke",
+    "startup_website_import": "utility-smoke",
+    "suggested_startups": "local-smoke",
+    "team_profile": "local-smoke",
+}
+
+SKILL_COVERAGE_REASONS = {
+    "contract-admin": "Operational skill with external or destructive side effects; covered by import/CLI contracts and focused existing tests.",
+    "docs-only": "Instruction-only skill package; import and SKILL.md contracts are the behavioral surface.",
+    "existing-unit": "Covered by existing focused tests outside the skill harness suite.",
+    "harness-smoke": "Covered through the slash-command harness with mocked service boundaries.",
+    "local-smoke": "Runs against local temp datasets with external services mocked.",
+    "utility-smoke": "Covered by deterministic local unit/smoke tests for cheap public behavior.",
+}
+
+HARNESS_SMOKE_COMMANDS = {
+    "/dataset_chat": "/dataset_chat example-startup What is the fixture?",
+    "/startup_profile": "/startup_profile example-startup",
+    "/startup_traction": "/startup_traction example-startup",
+    "/batch_audit": "/batch_audit example-startup {checklist}",
+    "/person_profile": "/person_profile sictic-members Jane Doe",
+    "/team_profile": "/team_profile example-startup",
+    "/investor_profile": "/investor_profile --source-dataset sictic-members",
+    "/expert_search": "/expert_search example-startup",
+    "/potential_investors": "/potential_investors example-startup",
+    "/advocates": "/advocates fixture-event --description Fixture event",
+    "/suggested_startups": (
+        "/suggested_startups --startups example-startup "
+        "--investors Jane Doe --max-startups 1"
+    ),
+    "/dd_checks": "/dd_checks example-startup",
+}

--- a/tests/skill_harness/conftest.py
+++ b/tests/skill_harness/conftest.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+import importlib
+from dataclasses import dataclass
+from types import SimpleNamespace
+
+import pytest
+
+from lib.datasets.paths import dataset_location_for_domain
+from lib.insights import InsightFile
+from lib.people.model import Person
+from lib.storage import get_storage, reset_storage_singleton
+
+
+@dataclass(frozen=True)
+class SkillHarnessFixtures:
+    startup: str = "example-startup"
+    community: str = "sictic-members"
+    generated: str = "sictic-members-investor-profile"
+    person_name: str = "Jane Doe"
+    person_linkedin_id: str = "jane-doe"
+
+    @property
+    def person(self) -> Person:
+        return Person(
+            full_name=self.person_name,
+            linkedin_id=self.person_linkedin_id,
+            email_addresses=["jane@example.com"],
+            linkedin_profile={"headline": "Angel investor"},
+        )
+
+
+def _create_dataset(name: str, domain: str) -> None:
+    storage = get_storage()
+    location = dataset_location_for_domain(name, domain)
+    storage.mkdir(location.raw_rel)
+    storage.mkdir(location.parsed_rel)
+    storage.mkdir(location.insights_rel)
+    storage.write_text(
+        f"{location.raw_rel}/fixture.md",
+        f"# {name}\n\nLocal fixture dataset for skill harness tests.\n",
+    )
+    storage.write_text(
+        f"{location.parsed_rel}/fixture.md",
+        f"# Parsed {name}\n\nJane Doe is connected to {name}.\n",
+    )
+
+
+@pytest.fixture
+def skill_fixture_storage(monkeypatch, tmp_path) -> SkillHarnessFixtures:
+    storage_root = tmp_path / "local-storage"
+    data_root = tmp_path / "local-data"
+    monkeypatch.setenv("LOCAL_STORAGE_PATH", str(storage_root))
+    monkeypatch.setenv("LOCAL_DATA_PATH", str(data_root))
+    monkeypatch.setenv("DEALUM_API_KEY", "")
+    monkeypatch.setenv("DEALUM_DEALROOM_ID", "")
+    monkeypatch.setenv("RANKED_LLMS", "ollama/test_model:1b")
+    reset_storage_singleton()
+
+    fixtures = SkillHarnessFixtures()
+    _create_dataset(fixtures.startup, "startups")
+    _create_dataset(fixtures.community, "community")
+    _create_dataset(fixtures.generated, "generated")
+
+    InsightFile(
+        fixtures.community,
+        "person_profile",
+        "ollama/test_model:1b",
+        identifier=fixtures.person_linkedin_id,
+        subdir=True,
+    ).save("# Jane Doe\n\nExperienced angel investor.")
+    get_storage().write_text(
+        "storage/community/sictic-members/datasets/track-record/jane-doe.md",
+        "Invested in fixture startups.",
+    )
+
+    yield fixtures
+    reset_storage_singleton()
+
+
+@pytest.fixture(autouse=True)
+def forbid_cloud_sync(monkeypatch):
+    def blocked(*_args, **_kwargs):
+        raise AssertionError("skill harness tests must not invoke Google Drive sync")
+
+    import skills.gdrive_sync.__main__ as gdrive_main
+    import skills.gdrive_sync.client as gdrive_client
+    import skills.gdrive_sync.drive_api as drive_api
+    import skills.gdrive_sync.incremental as incremental
+
+    monkeypatch.setattr(gdrive_main, "run_operation", blocked)
+    monkeypatch.setattr(gdrive_client.GDriveSync, "pull", blocked)
+    monkeypatch.setattr(gdrive_client.GDriveSync, "sync", blocked)
+    monkeypatch.setattr(incremental, "run_incremental_sync", blocked)
+    monkeypatch.setattr(drive_api.DriveApi, "_ensure_service", blocked)
+    monkeypatch.setattr(drive_api.DriveApi, "_load_or_authorize", blocked)
+
+
+@pytest.fixture
+def mocked_skill_boundaries(monkeypatch, skill_fixture_storage):
+    fixtures = skill_fixture_storage
+
+    async def fake_sync_datasets(*_args, **_kwargs):
+        return []
+
+    async def fake_dataset_chat(*_args, **_kwargs):
+        return '{"status": "Found", "summary": "Fixture answer", "concerns": "None"}'
+
+    async def fake_llm_chat(*_args, **_kwargs):
+        return "Fixture LLM profile."
+
+    async def fake_ranking_persons(*_args, **_kwargs):
+        return "| Rank | Person | Rationale |\n|---|---|---|\n| 1 | Jane Doe | Fixture match |"
+
+    async def fake_hydrate_dataset_from_insights(*_args, **_kwargs):
+        return SimpleNamespace(dataset_name=fixtures.generated, written=1)
+
+    async def fake_startup_profile(startup, *_args, **_kwargs):
+        insight = InsightFile(startup, "startup_profile", "manual")
+        if not insight.exists():
+            insight.save("# Fixture Startup Profile\n\nExample traction and market.")
+        return insight.content(), insight.path
+
+    async def fake_investor_profile(*_args, **_kwargs):
+        return SimpleNamespace(source_dataset=fixtures.community, person_profiles=1, written=1)
+
+    class FakeLinkedInResolver:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def get_profiles(self, persons):
+            return [
+                Person(
+                    full_name=person.full_name or fixtures.person_name,
+                    linkedin_id=person.linkedin_id or fixtures.person_linkedin_id,
+                    email_addresses=person.email_addresses or ["jane@example.com"],
+                    linkedin_profile={"headline": "Fixture investor"},
+                )
+                for person in persons
+            ]
+
+        def get_all_persons(self):
+            return [fixtures.person_name]
+
+    def fake_persons_in_dataset(*_args, **_kwargs):
+        return [fixtures.person]
+
+    async def fake_build_person_dossier(*_args, **_kwargs):
+        return [], []
+
+    async def fake_dataset_search(*_args, **_kwargs):
+        return []
+
+    async def fake_compile_startup_profiles(startups):
+        return {startup: f"# {startup}\n\nFixture startup profile." for startup in startups}
+
+    async def fake_process_single_investor(*_args, **_kwargs):
+        return ["| example-startup | Fixture rationale |"]
+
+    def fake_read_investor_profiles(*_args, **_kwargs):
+        return {fixtures.person_name: "# Jane Doe\n\nInvestor fixture."}
+
+    async def fake_ensure_startup_dataset(startup, **_kwargs):
+        return SimpleNamespace(dataset_slug="example-startup", dataset_exists=True)
+
+    people_discovery = importlib.import_module("lib.people.discovery")
+    startup_sources = importlib.import_module("lib.startups.sources")
+    advocates_mod = importlib.import_module("skills.advocates.advocates")
+    batch_audit_mod = importlib.import_module("skills.batch_audit.batch_audit")
+    dataset_chat_mod = importlib.import_module("skills.dataset_chat.dataset_chat")
+    dd_checks_mod = importlib.import_module("skills.dd_checks.dd_checks")
+    expert_search_mod = importlib.import_module("skills.expert_search.expert_search")
+    investor_profile_mod = importlib.import_module("skills.investor_profile.investor_profile")
+    person_profile_mod = importlib.import_module("skills.person_profile.person_profile")
+    potential_investors_mod = importlib.import_module(
+        "skills.potential_investors.potential_investors"
+    )
+    startup_profile_mod = importlib.import_module("skills.startup_profile.startup_profile")
+    startup_traction_mod = importlib.import_module("skills.startup_traction.startup_traction")
+    suggested_startups_mod = importlib.import_module(
+        "skills.suggested_startups.suggested_startups"
+    )
+    team_profile_mod = importlib.import_module("skills.team_profile.team_profile")
+
+    monkeypatch.setattr(startup_sources, "ensure_startup_dataset", fake_ensure_startup_dataset)
+    monkeypatch.setattr(people_discovery, "persons_in_dataset", fake_persons_in_dataset)
+
+    for module in [
+        startup_profile_mod,
+        startup_traction_mod,
+        person_profile_mod,
+        team_profile_mod,
+        dd_checks_mod,
+        expert_search_mod,
+        potential_investors_mod,
+        advocates_mod,
+        suggested_startups_mod,
+    ]:
+        if hasattr(module, "sync_datasets"):
+            monkeypatch.setattr(module, "sync_datasets", fake_sync_datasets)
+
+    monkeypatch.setattr(startup_profile_mod, "dataset_chat", fake_dataset_chat)
+    monkeypatch.setattr(startup_traction_mod, "dataset_chat", fake_dataset_chat)
+    monkeypatch.setattr(dataset_chat_mod, "dataset_chat", fake_dataset_chat)
+    monkeypatch.setattr(dd_checks_mod, "dataset_chat", fake_dataset_chat)
+    monkeypatch.setattr(batch_audit_mod, "dataset_chat", fake_dataset_chat)
+    monkeypatch.setattr(person_profile_mod, "llm_chat", fake_llm_chat)
+    monkeypatch.setattr(team_profile_mod, "llm_chat", fake_llm_chat)
+    monkeypatch.setattr(team_profile_mod, "dataset_search", fake_dataset_search)
+    monkeypatch.setattr(person_profile_mod, "LinkedInResolver", FakeLinkedInResolver)
+    monkeypatch.setattr(person_profile_mod, "persons_in_dataset", fake_persons_in_dataset)
+    monkeypatch.setattr(person_profile_mod, "build_person_dossier", fake_build_person_dossier)
+    monkeypatch.setattr(expert_search_mod, "startup_profile", fake_startup_profile)
+    monkeypatch.setattr(potential_investors_mod, "startup_profile", fake_startup_profile)
+
+    for module in [expert_search_mod, potential_investors_mod, advocates_mod]:
+        monkeypatch.setattr(module, "ranking_persons", fake_ranking_persons)
+        monkeypatch.setattr(module, "hydrate_dataset_from_insights", fake_hydrate_dataset_from_insights)
+
+    monkeypatch.setattr(suggested_startups_mod, "LinkedInResolver", FakeLinkedInResolver)
+    monkeypatch.setattr(suggested_startups_mod, "compile_startup_profiles", fake_compile_startup_profiles)
+    monkeypatch.setattr(suggested_startups_mod, "process_single_investor", fake_process_single_investor)
+    monkeypatch.setattr(suggested_startups_mod, "investor_profile", fake_investor_profile)
+    monkeypatch.setattr(suggested_startups_mod, "read_investor_profiles", fake_read_investor_profiles)
+
+    return fixtures

--- a/tests/skill_harness/test_skill_contracts.py
+++ b/tests/skill_harness/test_skill_contracts.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+
+from typer.testing import CliRunner
+
+from skills.harness.harness import build_registry
+from skills.skill_registry import SKILL_REGISTRY
+from tests.skill_harness.cases import (
+    ADMIN_ONLY_HARNESS_COMMANDS,
+    HARNESS_SMOKE_COMMANDS,
+    SKILL_COVERAGE,
+    SKILL_COVERAGE_REASONS,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILLS_ROOT = REPO_ROOT / "skills"
+
+
+def _skill_dirs() -> list[Path]:
+    return sorted(path.parent for path in SKILLS_ROOT.glob("*/SKILL.md"))
+
+
+def test_every_skill_markdown_directory_is_importable_package():
+    for skill_dir in _skill_dirs():
+        package_name = f"skills.{skill_dir.name}"
+        importlib.import_module(package_name)
+
+
+def test_every_skill_main_renders_typer_help():
+    for main_path in sorted(SKILLS_ROOT.glob("*/__main__.py")):
+        module_name = f"skills.{main_path.parent.name}.__main__"
+        module = importlib.import_module(module_name)
+
+        result = CliRunner().invoke(module.app, ["--help"])
+
+        assert result.exit_code == 0, module_name
+        assert "Usage:" in result.output
+
+
+def test_harness_registry_commands_are_smoked_or_marked_admin_only():
+    registered = set(build_registry())
+    covered = set(HARNESS_SMOKE_COMMANDS) | ADMIN_ONLY_HARNESS_COMMANDS
+
+    assert registered <= covered
+
+
+def test_skill_registry_dependencies_reference_existing_keys():
+    registered = set(SKILL_REGISTRY)
+
+    for name, spec in SKILL_REGISTRY.items():
+        assert set(spec.depends_on) <= registered, name
+
+
+def test_every_skill_has_explicit_harness_coverage_classification():
+    skill_names = {path.name for path in _skill_dirs()}
+
+    assert set(SKILL_COVERAGE) == skill_names
+    assert set(SKILL_COVERAGE.values()) <= set(SKILL_COVERAGE_REASONS)

--- a/tests/skill_harness/test_skill_smoke.py
+++ b/tests/skill_harness/test_skill_smoke.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import pytest
+
+from lib.insights import InsightFile
+from lib.storage import get_storage
+from skills.harness.harness import dispatch_command
+from tests.skill_harness.cases import HARNESS_SMOKE_COMMANDS
+
+
+@pytest.mark.asyncio
+async def test_startup_profile_uses_local_fixture_storage(mocked_skill_boundaries):
+    from skills.startup_profile.startup_profile import startup_profile
+
+    content, path = await startup_profile("example-startup")
+
+    assert "Fixture answer" in content
+    assert path.startswith("storage/startups/example-startup/insights/")
+    assert get_storage().exists(path)
+
+
+@pytest.mark.asyncio
+async def test_startup_traction_uses_local_fixture_storage(mocked_skill_boundaries):
+    from skills.startup_traction.startup_traction import startup_traction
+
+    content = await startup_traction("example-startup")
+
+    assert "Fixture answer" in content
+    assert InsightFile("example-startup", "startup_traction", "ollama/test_model:1b").exists()
+
+
+@pytest.mark.asyncio
+async def test_person_profile_uses_fixture_people_and_linkedin(mocked_skill_boundaries):
+    from skills.person_profile.person_profile import person_profile
+
+    people = await person_profile("sictic-members", "Jane Doe")
+
+    assert len(people) == 1
+    assert people[0].full_name == "Jane Doe"
+    assert "Full-name: Jane Doe" in people[0].person_profile
+
+
+@pytest.mark.asyncio
+async def test_team_profile_uses_mocked_person_context(mocked_skill_boundaries):
+    from skills.team_profile.team_profile import team_profile
+
+    content, path = await team_profile("example-startup")
+
+    assert "Fixture LLM profile" in content
+    assert path.startswith("storage/startups/example-startup/insights/")
+    assert get_storage().exists(path)
+
+
+@pytest.mark.asyncio
+async def test_investor_profile_composes_from_local_insights(mocked_skill_boundaries):
+    from skills.investor_profile.investor_profile import investor_profile
+
+    result = await investor_profile("sictic-members")
+
+    assert result.person_profiles == 1
+    assert result.written == 1
+    assert InsightFile(
+        "sictic-members",
+        "investor_profile",
+        "ollama/test_model:1b",
+        identifier="jane-doe",
+        subdir=True,
+    ).exists()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("module_name", "function_name", "args", "expected"),
+    [
+        (
+            "skills.expert_search.expert_search",
+            "expert_search",
+            ("example-startup",),
+            "Jane Doe",
+        ),
+        (
+            "skills.potential_investors.potential_investors",
+            "potential_investors",
+            ("example-startup",),
+            "Jane Doe",
+        ),
+        (
+            "skills.advocates.advocates",
+            "advocates",
+            ("fixture-event", "Fixture event"),
+            "Jane Doe",
+        ),
+        (
+            "skills.suggested_startups.suggested_startups",
+            "suggested_startups",
+            ("sictic-members", ["example-startup"], ["Jane Doe"], 1),
+            "Processed Jane Doe",
+        ),
+    ],
+)
+async def test_ranking_style_skills_smoke(
+    mocked_skill_boundaries,
+    module_name,
+    function_name,
+    args,
+    expected,
+):
+    module = __import__(module_name, fromlist=[function_name])
+
+    result = await getattr(module, function_name)(*args)
+
+    assert expected in result
+
+
+@pytest.mark.asyncio
+async def test_dd_checks_writes_report_from_local_fixture(mocked_skill_boundaries):
+    from skills.dd_checks.dd_checks import dd_checks
+
+    path = await dd_checks("example-startup")
+
+    assert path.startswith("storage/startups/example-startup/insights/")
+    assert "Due Diligence" in get_storage().read_text(path)
+
+
+@pytest.mark.asyncio
+async def test_batch_audit_writes_checklist_insight(mocked_skill_boundaries):
+    from skills.batch_audit.batch_audit import batch_audit
+
+    result = await batch_audit("example-startup", "# Commercial\n- Is there traction?")
+
+    assert "| 1.1 | Is there traction?" in result
+    assert InsightFile(
+        "example-startup",
+        "batch_audit",
+        "ollama/test_model:1b",
+        identifier="Commercial",
+        subdir=True,
+    ).exists()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("command_name", sorted(HARNESS_SMOKE_COMMANDS))
+async def test_harness_core_command_smoke(command_name, mocked_skill_boundaries, tmp_path):
+    checklist = tmp_path / "checklist.md"
+    checklist.write_text("# Commercial\n- Is there traction?\n", encoding="utf-8")
+    command = HARNESS_SMOKE_COMMANDS[command_name].format(checklist=checklist)
+
+    result = await dispatch_command(command)
+
+    assert result
+    assert "Traceback" not in result

--- a/tests/skill_harness/test_skill_utilities.py
+++ b/tests/skill_harness/test_skill_utilities.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_llm_chat_uses_gateway_without_live_model(monkeypatch):
+    from skills.llm_chat.llm_chat import llm_chat
+    import skills.llm_chat.llm_chat as llm_chat_mod
+
+    captured = {}
+
+    async def fake_completion(kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(content="fixture completion")
+                )
+            ]
+        )
+
+    monkeypatch.setattr(llm_chat_mod.gateway, "request_completion", fake_completion)
+
+    result = await llm_chat("Summarize the fixture.")
+
+    assert result == "fixture completion"
+    assert captured["messages"][0]["content"] == "Summarize the fixture."
+    assert captured["num_ctx"] == 4096
+
+
+@pytest.mark.asyncio
+async def test_ranking_rank_chunk_appends_missing_ids(monkeypatch):
+    import skills.ranking.ranking_top_k as ranking_top_k_mod
+
+    monkeypatch.setattr(
+        ranking_top_k_mod,
+        "config_load",
+        lambda: {
+            "ranking_top_k": {
+                "ranking_instructions": (
+                    "{{objective}}\n{{profiles_text}}\n{{n_profiles}}\n{{IDs_profiles}}"
+                )
+            }
+        },
+    )
+
+    async def fake_llm_chat(*_args, **_kwargs):
+        return '{"ranked_profiles_ids": ["b"]}'
+
+    monkeypatch.setattr(ranking_top_k_mod, "llm_chat", fake_llm_chat)
+
+    result = await ranking_top_k_mod.rank_chunk(
+        "fixture objective",
+        {"a": "Profile A", "b": "Profile B"},
+    )
+
+    assert result == ["b", "a"]
+
+
+@pytest.mark.asyncio
+async def test_dealum_import_delegates_to_importer(monkeypatch):
+    import skills.dealum_import.dealum_import as dealum_import_mod
+
+    expected = SimpleNamespace(dataset_slug="example-startup")
+
+    def fake_import_startup_from_dealum(startup):
+        assert startup == "Example Startup"
+        return expected
+
+    monkeypatch.setattr(
+        dealum_import_mod,
+        "import_startup_from_dealum",
+        fake_import_startup_from_dealum,
+    )
+
+    result = await dealum_import_mod.dealum_import("Example Startup")
+
+    assert result is expected
+
+
+def test_linkedin_maintenance_formats_unique_missing_urls():
+    from skills.linkedin_maintenance.maintenance import missing_profile_urls
+
+    result = missing_profile_urls(
+        [
+            {"linkedin_id": "jane-doe"},
+            {"linkedin_id": "jane-doe/"},
+            {"linkedin_id": ""},
+            {},
+        ]
+    )
+
+    assert result == ["https://www.linkedin.com/in/jane-doe/"]
+
+
+def test_dataset_maintenance_filters_orphaned_qdrant_collections(skill_fixture_storage):
+    from skills.dataset_maintenance.maintenance import orphaned_qdrant_collections
+
+    class FakeAdmin:
+        def list_collections(self):
+            return [
+                "example-startup-test-embedding-8b",
+                "orphan-test-embedding-8b",
+                "unrelated-other-model",
+            ]
+
+    result = orphaned_qdrant_collections(admin=FakeAdmin())
+
+    assert result == ["orphan-test-embedding-8b"]
+
+
+def test_startup_website_import_validates_limits():
+    from skills.startup_website_import.startup_website_import import (
+        startup_website_import,
+    )
+
+    with pytest.raises(ValueError, match="depth"):
+        startup_website_import("Example Startup", "https://example.com", depth=-1)
+
+
+def test_standards_and_architecture_skill_is_instruction_only():
+    from pathlib import Path
+
+    path = Path("skills/standards_and_architecture/SKILL.md")
+
+    assert path.is_file()
+    assert "Data Storage Layout" in path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- add a pytest skill harness with temp local storage fixtures and cloud-sync guards
- classify coverage for every skill package and enforce import/CLI/harness contracts
- add deterministic smoke and utility tests for business and support skills

## Tests
- conda run -n sictic-env pytest tests/skill_harness tests/cli/test_entrypoint_contract.py tests/harness/test_harness.py
- conda run -n sictic-env pytest tests/skills tests/startup_profile tests/person_profile tests/potential_investors tests/utils/test_insight_file.py

No live Google Drive, Qdrant, LLM, Apify, Dealum, or web-search calls are used by the new harness tests.