### PR TITLE
Add codebase assessment and targeted fixes

### DIFF
--- a/docs/codebase-assessment.md
+++ b/docs/codebase-assessment.md
@@ -1,0 +1,53 @@
+# Codebase Assessment
+
+## Summary
+
+The repository is organized around user-facing `skills/` packages and shared
+`lib/` infrastructure, with tests covering many core workflows. The current
+highest-risk architectural issue is packaging: runtime imports and config
+loading still assume the source repository is on `sys.path` through the
+installer-generated `.pth` file. That should be handled in the separate
+self-contained installer PR.
+
+This assessment PR keeps changes low risk: it fixes a workspace synchronization
+bug and removes a repo-owned Pydantic v2 deprecation warning.
+
+## Findings
+
+### Fixed in this PR
+
+- `skills.sictic_git_sync` copied any directory under `skills/` into the AI
+  workspace, including helper packages without `SKILL.md`. It now copies only
+  manifest-bearing skill directories.
+- `skills.sictic_git_sync` could ingest arbitrary unmanaged workspace folders
+  into the repo as skills. It now skips unmanaged workspace directories unless
+  they are actual skill directories with `SKILL.md`.
+- `skills.ranking.ranking_top_k.RankedProfilesResult` used deprecated Pydantic
+  `Config`; it now uses `ConfigDict`.
+
+### Follow-up risks
+
+- Package import ambiguity exists in several skill packages where
+  `skills.<name>.__init__` exports functions with the same name as submodules.
+  This can confuse tests and monkeypatching. Prefer importing submodules with
+  `importlib.import_module(...)` until a broader export policy is chosen.
+- Many business skills catch broad `Exception` and rethrow generic
+  `RuntimeError` or continue with partial output. This is sometimes intentional
+  for batch workflows, but it makes operational failures harder to classify.
+- Several modules still read `REPO_PATH` directly for config and runtime files.
+  The packaging PR should decide whether installed code treats the install
+  directory as `REPO_PATH` or introduces a separate application root.
+- Google Drive sync remains intentionally isolated in `skills.gdrive_sync`, but
+  tests should continue asserting no general storage code imports Drive APIs.
+
+## Recommended Next PRs
+
+- Self-contained installer packaging: copy `skills`, `lib`, `config`,
+  `scripts`, and support files into the install root; point `.pth` at that
+  installed root; create an installed `.env` from `.env-template` without
+  copying secrets by default.
+- Error-boundary cleanup: replace broad catches in high-value paths with
+  typed exceptions or structured result objects where failures need to be
+  actionable.
+- Import policy cleanup: remove or standardize package-level function exports
+  that shadow submodule names.

--- a/skills/ranking/ranking_top_k.py
+++ b/skills/ranking/ranking_top_k.py
@@ -1,7 +1,7 @@
 import asyncio
 import random
 from typing import Dict, List, Any, Tuple
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from skills.llm_chat.llm_chat import llm_chat
 from skills.config_load.config_load import config_load
@@ -11,13 +11,12 @@ from lib.logger import get_logger
 logger = get_logger(__name__)
 
 class RankedProfilesResult(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
     ranked_profile_ids: List[str] = Field(
         description="List of profile IDs ordered from best to worst",
         alias="ranked_profiles_ids"
     )
-
-    class Config:
-        populate_by_name = True
 
 async def rank_chunk(objective: str, profiles: Dict[str, str]) -> List[str]:
     """Ranks a small set of profiles using LLM and returns sorted profile IDs."""

--- a/skills/sictic_git_sync/sictic_git_sync.py
+++ b/skills/sictic_git_sync/sictic_git_sync.py
@@ -7,6 +7,10 @@ from lib.logger import get_logger
 logger = get_logger(__name__)
 IGNORED_COPY_NAMES = {"__pycache__", ".DS_Store"}
 
+
+def _is_skill_dir(path: Path) -> bool:
+    return path.is_dir() and (path / "SKILL.md").is_file()
+
 def run_cmd(cmd: list[str], cwd: Path) -> str:
     """Executes a shell command and returns the output."""
     try:
@@ -53,6 +57,9 @@ def _reconcile_workspace_copies(repo_dir: Path, workspace_dir: Path) -> list[str
             item.unlink()
             logs.append(f"Removed workspace symlink: {item.name}")
         elif item.is_dir():
+            if not _is_skill_dir(item):
+                logs.append(f"Skipped unmanaged non-skill workspace folder: {item.name}")
+                continue
             repo_item = repo_skills / item.name
             if repo_item.exists():
                 continue
@@ -63,7 +70,11 @@ def _reconcile_workspace_copies(repo_dir: Path, workspace_dir: Path) -> list[str
 
     # 2. Scan repo: copy all skills into the workspace.
     for repo_item in repo_skills.iterdir():
-        if not repo_item.is_dir() or repo_item.name.startswith(".") or repo_item.name in IGNORED_COPY_NAMES:
+        if (
+            not _is_skill_dir(repo_item)
+            or repo_item.name.startswith(".")
+            or repo_item.name in IGNORED_COPY_NAMES
+        ):
             continue
             
         workspace_item = workspace_dir / repo_item.name

--- a/tests/skills/test_sictic_git_sync.py
+++ b/tests/skills/test_sictic_git_sync.py
@@ -33,3 +33,31 @@ def test_reconcile_workspace_replaces_old_symlink_install(tmp_path):
     assert (workspace / "sample").is_dir()
     assert not (workspace / "sample").is_symlink()
     assert (workspace / "sample" / "SKILL.md").read_text(encoding="utf-8") == "fresh\n"
+
+
+def test_reconcile_workspace_ignores_repo_directories_without_skill_manifest(tmp_path):
+    repo = tmp_path / "repo"
+    workspace = tmp_path / "workspace"
+    helper_dir = repo / "skills" / "helper_package"
+    helper_dir.mkdir(parents=True)
+    (helper_dir / "__init__.py").write_text("", encoding="utf-8")
+
+    logs = _reconcile_workspace_copies(repo, workspace)
+
+    assert "Copied repo skill into workspace: helper_package" not in logs
+    assert not (workspace / "helper_package").exists()
+
+
+def test_reconcile_workspace_does_not_ingest_non_skill_workspace_folders(tmp_path):
+    repo = tmp_path / "repo"
+    workspace = tmp_path / "workspace"
+    (repo / "skills").mkdir(parents=True)
+    notes = workspace / "notes"
+    notes.mkdir(parents=True)
+    (notes / "README.md").write_text("workspace notes\n", encoding="utf-8")
+
+    logs = _reconcile_workspace_copies(repo, workspace)
+
+    assert "Skipped unmanaged non-skill workspace folder: notes" in logs
+    assert (workspace / "notes" / "README.md").is_file()
+    assert not (repo / "skills" / "notes").exists()


### PR DESCRIPTION
## Summary
- add a tracked codebase assessment covering fixed issues and follow-up risks
- restrict sictic_git_sync workspace reconciliation to real skill directories with SKILL.md
- migrate ranking_top_k Pydantic config to ConfigDict

## Tests
- conda run -n sictic-env pytest tests/skills/test_sictic_git_sync.py tests/ranking
- conda run -n sictic-env pytest tests/skills tests/ranking tests/utils/test_services_gateway.py tests/utils/test_storage_gdrive_write_safety.py

## Notes
- Packaging work is intentionally left for the next PR.