### PR TITLE
Bound provider calls and reclaim expired leases in services gateway

### DIFF
--- a/lib/services_gateway.py
+++ b/lib/services_gateway.py
@@ -21,6 +21,23 @@ logger = get_logger(__name__)
 _RESOURCE_KEYS = ("docling", "embedding", "llm")
 _DEFAULT_WAIT_TIMEOUT = 3600.0
 _POLL_INTERVAL = 0.5
+# A lease held longer than this is treated as leaked and reclaimed even if
+# the owning process is still alive: a hung provider call never returns, so
+# pid-liveness alone cannot distinguish a stuck job from a long one.
+_DEFAULT_LEASE_MAX_AGE = 1800.0
+_DEFAULT_LLM_REQUEST_TIMEOUT = 600.0
+_DEFAULT_EMBEDDING_REQUEST_TIMEOUT = 300.0
+
+
+def _float_env(name: str, default: float) -> float:
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        logger.warning("Ignoring non-numeric %s=%r", name, raw)
+        return default
 
 
 class GatewayTimeoutError(TimeoutError):
@@ -108,6 +125,7 @@ class ServicesGateway:
         ollama_max_loaded_models: int | None = None,
         wait_timeout: float = _DEFAULT_WAIT_TIMEOUT,
         poll_interval: float = _POLL_INTERVAL,
+        lease_max_age: float | None = None,
     ):
         self.state_path = Path(
             state_path or default_gateway_state_path()
@@ -124,6 +142,11 @@ class ServicesGateway:
         )
         self.wait_timeout = wait_timeout
         self.poll_interval = poll_interval
+        self.lease_max_age = (
+            lease_max_age
+            if lease_max_age is not None
+            else _float_env("GATEWAY_LEASE_MAX_AGE", _DEFAULT_LEASE_MAX_AGE)
+        )
         self._process_start = _process_start_token(os.getpid()) or str(
             time.time_ns()
         )
@@ -170,6 +193,24 @@ class ServicesGateway:
             return self._empty_state()
         cleaned = self._empty_state()
         process_alive: dict[tuple[int, str], bool] = {}
+        now = time.time()
+
+        def lease_is_current(lease: dict) -> bool:
+            try:
+                age = now - float(lease["acquired_at"])
+            except (KeyError, TypeError, ValueError):
+                return False
+            if age <= self.lease_max_age:
+                return True
+            logger.warning(
+                "Reclaiming expired %s lease held by pid %s "
+                "(age %.0fs > max %.0fs)",
+                lease.get("resource"),
+                lease.get("pid"),
+                age,
+                self.lease_max_age,
+            )
+            return False
 
         def entry_is_alive(entry: dict) -> bool:
             try:
@@ -189,7 +230,9 @@ class ServicesGateway:
                 cleaned["leases"][resource] = [
                     lease
                     for lease in pool
-                    if isinstance(lease, dict) and entry_is_alive(lease)
+                    if isinstance(lease, dict)
+                    and entry_is_alive(lease)
+                    and lease_is_current(lease)
                 ]
             queue = requests.get(resource, [])
             if isinstance(queue, list):
@@ -481,6 +524,15 @@ class ServicesGateway:
         import litellm
 
         litellm.disable_aiohttp_transport = True
+        # Bound the provider call so a hung connection raises and releases
+        # its lease instead of blocking the machine-wide slot forever.
+        kwargs.setdefault(
+            "timeout",
+            _float_env(
+                "EMBEDDING_REQUEST_TIMEOUT",
+                _DEFAULT_EMBEDDING_REQUEST_TIMEOUT,
+            ),
+        )
         async with self.slot(
             "embedding",
             model=str(kwargs.get("model") or "embedding"),
@@ -498,6 +550,15 @@ class ServicesGateway:
         import litellm
 
         litellm.disable_aiohttp_transport = True
+        # Bound the provider call so a hung connection raises and releases
+        # its lease instead of blocking the machine-wide slot forever.
+        kwargs.setdefault(
+            "timeout",
+            _float_env(
+                "LLM_REQUEST_TIMEOUT",
+                _DEFAULT_LLM_REQUEST_TIMEOUT,
+            ),
+        )
         async with self.slot(
             "llm",
             model=str(kwargs.get("model") or "llm"),

--- a/tests/utils/test_services_gateway.py
+++ b/tests/utils/test_services_gateway.py
@@ -376,6 +376,79 @@ async def test_three_services_share_model_slots_equally(tmp_path):
                 }
 
 
+def test_expired_lease_from_live_process_is_reclaimed(tmp_path):
+    gateway = ServicesGateway(
+        state_path=tmp_path / "gateway.json",
+        ollama_num_parallel=2,
+        ollama_max_loaded_models=2,
+        wait_timeout=1,
+        poll_interval=0.01,
+        lease_max_age=60,
+    )
+
+    def make_lease(lease_id, acquired_at):
+        return {
+            "lease_id": lease_id,
+            "resource": "llm",
+            "model": "llm",
+            "pid": os.getpid(),
+            "process_start": gateway._process_start,
+            "acquired_at": acquired_at,
+        }
+
+    gateway.state_path.parent.mkdir(parents=True, exist_ok=True)
+    gateway.state_path.write_text(
+        json.dumps(
+            {
+                "version": 4,
+                "leases": {
+                    "docling": [],
+                    "embedding": [],
+                    "llm": [
+                        make_lease("expired", time.time() - 3600),
+                        make_lease("fresh", time.time()),
+                    ],
+                },
+                "requests": {"docling": [], "embedding": [], "llm": []},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    remaining = _leases(gateway, "llm")
+
+    assert [lease["lease_id"] for lease in remaining] == ["fresh"]
+
+
+@pytest.mark.asyncio
+async def test_completion_applies_default_request_timeout(
+    clean_gateway,
+    mocker,
+):
+    completion = mocker.patch(
+        "litellm.acompletion",
+        return_value="Mocked LLM",
+    )
+
+    await clean_gateway.request_completion({"model": "ollama/llm"})
+
+    assert completion.call_args.kwargs["timeout"] == 600.0
+
+
+@pytest.mark.asyncio
+async def test_caller_request_timeout_is_preserved(clean_gateway, mocker):
+    embedding = mocker.patch(
+        "litellm.aembedding",
+        return_value="Mocked Embedding",
+    )
+
+    await clean_gateway.request_embedding(
+        {"model": "ollama/embed", "timeout": 42}
+    )
+
+    assert embedding.call_args.kwargs["timeout"] == 42
+
+
 def test_dead_or_reused_pid_lease_is_cleaned(clean_gateway):
     clean_gateway.state_path.parent.mkdir(parents=True, exist_ok=True)
     clean_gateway.state_path.write_text(


### PR DESCRIPTION
Fixes #23

A hung litellm HTTP call never returns, so its gateway lease was held until the owning process died. With the machine-wide LLM cap of 2, two hung calls froze every skill in every process for the full 3600s wait timeout. Observed after switching `LLM_MODEL` to a cloud provider: a stalled `batch_audit` in a long-running MCP server process gridlocked the machine for an hour (13 requests queued behind 2 leaked leases held by an idle process).

**Fix, two layers:**
- `request_completion` / `request_embedding` now set a default litellm `timeout` (`LLM_REQUEST_TIMEOUT`=600s / `EMBEDDING_REQUEST_TIMEOUT`=300s, env-overridable; explicit caller kwargs win). A hung connection now raises and releases its lease through the existing slot cleanup.
- State cleanup reclaims leases older than `GATEWAY_LEASE_MAX_AGE` (default 1800s) even when the owning pid is alive, since pid-liveness cannot distinguish a stuck job from a long one. Reclaims log a warning with pid and age.

`_DEFAULT_WAIT_TIMEOUT` (3600s queue wait) is intentionally unchanged: with individual calls bounded, queues drain, and fan-out skills legitimately queue many requests behind the 2-slot cap.

**Tested:** 3 new unit tests (expired-lease reclaim, default timeout applied, caller timeout preserved); gateway suite 20/20; live verification against both a cloud provider (Gemini) and local Ollama (qwen3:8b + nomic-embed-text), including concurrent use from two processes. Note: `tests/skill_harness` has 35 pre-existing collection errors on `main` (conftest imports `skills.gdrive_sync.__main__`, removed in #14) — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)