### PR TITLE
Fix harness parse error on apostrophes in queries

### DIFF
--- a/skills/harness/harness.py
+++ b/skills/harness/harness.py
@@ -258,7 +258,13 @@ async def dispatch_command(line: str, registry: Dict[str, HarnessCommand] | None
         return "Use slash commands. Type /help for available commands."
 
     try:
-        parts = shlex.split(stripped)
+        # Only double quotes group tokens; apostrophes in natural-language
+        # queries (e.g. "What's ...") must not open a quote.
+        lexer = shlex.shlex(stripped, posix=True)
+        lexer.quotes = '"'
+        lexer.whitespace_split = True
+        lexer.commenters = ""
+        parts = list(lexer)
     except ValueError as e:
         return f"Parse error: {e}"
 

--- a/tests/harness/test_harness.py
+++ b/tests/harness/test_harness.py
@@ -18,6 +18,42 @@ async def test_harness_dispatches_registered_command():
 
 
 @pytest.mark.asyncio
+async def test_harness_apostrophe_in_query_is_not_a_parse_error():
+    async def handler(args):
+        return " ".join(args)
+
+    registry = {
+        "/echo": HarnessCommand("/echo", "/echo <text>", "Echo text.", handler)
+    }
+
+    result = await dispatch_command("/echo What's the funding ask?", registry)
+
+    assert "Parse error" not in result
+    assert result == "What's the funding ask?"
+
+
+@pytest.mark.asyncio
+async def test_harness_double_quotes_group_strip_and_keep_apostrophe():
+    async def handler(args):
+        return f"{len(args)}|" + "|".join(args)
+
+    registry = {
+        "/echo": HarnessCommand("/echo", "/echo <text>", "Echo text.", handler)
+    }
+
+    result = await dispatch_command('/echo "What\'s the funding ask?"', registry)
+
+    assert result == "1|What's the funding ask?"
+
+
+@pytest.mark.asyncio
+async def test_harness_empty_input_returns_empty_string():
+    result = await dispatch_command("   ")
+
+    assert result == ""
+
+
+@pytest.mark.asyncio
 async def test_harness_unknown_command_is_readable():
     result = await dispatch_command("/missing")
 


### PR DESCRIPTION
Fixes #22

`dispatch_command` tokenized input with `shlex.split` in POSIX mode, so a bare apostrophe (e.g. `What's`) opened an unterminated quote and every such query failed with `Parse error: No closing quotation`.

This switches tokenization to a `shlex.shlex` instance configured to treat only double quotes as quote characters: apostrophes pass through as literal text, while double-quoted arguments still group into a single token with the quotes stripped.

Includes regression tests covering apostrophes, double-quoted arguments, and mixed cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)