### PR TITLE
Bug fixes: wrong page numbers and allowing no cloud service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ __pycache__/
 .pytest-storage/
 .storage/
 .storage-mirror/
+.installed-skills/
 gdrive-mirror/
 gdrive-sync/.state/
 gdrive-sync/logs/

--- a/install.sh
+++ b/install.sh
@@ -476,7 +476,7 @@ if [ "$INTERACTIVE" -eq 1 ]; then
     ask_env "WORKSPACE_PATH" "Installed skills path" "$TARGET" 1 0
     ask_env "LOCAL_STORAGE_PATH" "Local application storage path" "$REPO_ROOT/.storage" 1 0
     ask_env "LOCAL_DATA_PATH" "Local runtime cache path" "$REPO_ROOT" 1 0
-    ask_env "CLOUD_PROVIDER" "Cloud provider (blank or google)" "google" 0 0
+    ask_env "CLOUD_PROVIDER" "Cloud provider (blank or google)" "" 0 0
     cloud_provider=$(env_get CLOUD_PROVIDER || true)
     case "$(printf '%s' "$cloud_provider" | tr '[:upper:]' '[:lower:]')" in
         "") ;;

--- a/lib/adapters/docling/converter.py
+++ b/lib/adapters/docling/converter.py
@@ -85,11 +85,36 @@ def get_converter():
     return _converter
 
 
+def export_document_markdown(document) -> str:
+    """Export Markdown with explicit page markers when Docling has page data."""
+    from lib.datasets.page_markers import format_page_marker
+
+    page_numbers = sorted(document.pages.keys())
+    if not page_numbers:
+        return document.export_to_markdown()
+
+    if len(page_numbers) == 1:
+        page_no = page_numbers[0]
+        body = document.export_to_markdown().strip()
+        if not body:
+            return ""
+        return f"{format_page_marker(page_no)}\n\n{body}"
+
+    parts: list[str] = []
+    for page_no in page_numbers:
+        page_md = document.export_to_markdown(page_no=page_no).strip()
+        if page_md:
+            parts.append(f"{format_page_marker(page_no)}\n\n{page_md}")
+    if parts:
+        return "\n\n".join(parts)
+    return document.export_to_markdown()
+
+
 def convert_document(filepath: str) -> str:
     converter = get_converter()
     with _convert_lock:
         result = converter.convert(filepath)
-    return result.document.export_to_markdown()
+    return export_document_markdown(result.document)
 
 
 def chat_completions_url(base_url: str) -> str:

--- a/lib/datasets/chunking.py
+++ b/lib/datasets/chunking.py
@@ -6,24 +6,27 @@ import uuid
 from langchain_text_splitters import MarkdownTextSplitter
 
 from lib.datasets.models import Chunk
+from lib.datasets.page_markers import split_text_by_pages
 
 
 def split_markdown(text: str, filename: str, mod_time: float) -> list[Chunk]:
     splitter = MarkdownTextSplitter(chunk_size=1000, chunk_overlap=100)
-    docs = splitter.create_documents([text])
-    chunks = []
-    for index, doc in enumerate(docs):
-        content = doc.page_content
-        chunk_hash = hashlib.md5(
-            f"{filename}_{content}".encode("utf-8")
-        ).hexdigest()
-        chunks.append(
-            Chunk(
-                chunk_id=str(uuid.UUID(hex=chunk_hash)),
-                document_name=filename,
-                page_number=(index // 5) + 1,
-                last_modified=mod_time,
-                text=content,
+    chunks: list[Chunk] = []
+    for page_number, section_text in split_text_by_pages(text):
+        if not section_text.strip():
+            continue
+        for doc in splitter.create_documents([section_text]):
+            content = doc.page_content
+            chunk_hash = hashlib.md5(
+                f"{filename}_{content}".encode("utf-8")
+            ).hexdigest()
+            chunks.append(
+                Chunk(
+                    chunk_id=str(uuid.UUID(hex=chunk_hash)),
+                    document_name=filename,
+                    page_number=page_number,
+                    last_modified=mod_time,
+                    text=content,
+                )
             )
-        )
     return chunks

--- a/lib/datasets/manifest.py
+++ b/lib/datasets/manifest.py
@@ -15,7 +15,7 @@ logger = get_logger(__name__)
 
 MANIFEST_FILENAME = ".ingestion-manifest.json"
 MANIFEST_VERSION = 1
-PARSER_VERSION = "docling-values-v2"
+PARSER_VERSION = "docling-page-markers-v1"
 CHUNKER_VERSION = "markdown-1000-100-v1"
 
 

--- a/lib/datasets/models.py
+++ b/lib/datasets/models.py
@@ -40,4 +40,7 @@ class Chunk(BaseModel):
 
     def to_md(self) -> str:
         """Renders the chunk as a standalone Markdown block."""
-        return f"### Source: {self.document_name} | Page: {self.page_number}\n\n{self.text.strip()}"
+        header = f"### Source: {self.document_name}"
+        if self.page_number != "n/a":
+            header = f"{header} | Page: {self.page_number}"
+        return f"{header}\n\n{self.text.strip()}"

--- a/lib/datasets/page_markers.py
+++ b/lib/datasets/page_markers.py
@@ -1,0 +1,35 @@
+"""Page boundary markers embedded in parsed Markdown."""
+
+from __future__ import annotations
+
+import re
+
+PAGE_MARKER_RE = re.compile(r"<!-- sictic-page:(\d+) -->\s*")
+UNKNOWN_PAGE = "n/a"
+
+
+def format_page_marker(page: int) -> str:
+    return f"<!-- sictic-page:{page} -->"
+
+
+def split_text_by_pages(text: str) -> list[tuple[int | str, str]]:
+    """Split parsed Markdown into (page_number, section_text) pairs."""
+    if not PAGE_MARKER_RE.search(text):
+        stripped = text.strip()
+        return [(UNKNOWN_PAGE, stripped)] if stripped else []
+
+    sections: list[tuple[int | str, str]] = []
+    current_page: int | str = UNKNOWN_PAGE
+    cursor = 0
+
+    for match in PAGE_MARKER_RE.finditer(text):
+        prefix = text[cursor:match.start()].strip()
+        if prefix:
+            sections.append((current_page, prefix))
+        current_page = int(match.group(1))
+        cursor = match.end()
+
+    remainder = text[cursor:].strip()
+    if remainder:
+        sections.append((current_page, remainder))
+    return sections

--- a/skills/dataset_chat/__main__.py
+++ b/skills/dataset_chat/__main__.py
@@ -21,8 +21,13 @@ def search_cmd(
         logger=logger,
     )
     for chunk in chunks:
+        source_label = (
+            f"[Source: {chunk.document_name}]"
+            if chunk.page_number == "n/a"
+            else f"[Source: {chunk.document_name}, Page: {chunk.page_number}]"
+        )
         typer.echo(
-            f"[Source: {chunk.document_name}, Page: {chunk.page_number}]\n"
+            f"{source_label}\n"
             f"{chunk.text}\n"
         )
 

--- a/tests/dataset_chat/test_chunking.py
+++ b/tests/dataset_chat/test_chunking.py
@@ -1,7 +1,51 @@
 import hashlib
 import uuid
+from types import SimpleNamespace
 
+from lib.adapters.docling.converter import export_document_markdown
 from lib.datasets.chunking import split_markdown
+from lib.datasets.models import Chunk
+from lib.datasets.page_markers import format_page_marker, split_text_by_pages
+
+
+def test_split_text_by_pages_without_markers():
+    sections = split_text_by_pages("Plain text without page markers.")
+    assert sections == [("n/a", "Plain text without page markers.")]
+
+
+def test_split_text_by_pages_with_markers():
+    text = (
+        f"{format_page_marker(1)}\n\nFirst page text.\n\n"
+        f"{format_page_marker(3)}\n\nThird page text."
+    )
+    sections = split_text_by_pages(text)
+    assert sections == [(1, "First page text."), (3, "Third page text.")]
+
+
+def test_split_markdown_assigns_real_page_numbers():
+    text = (
+        f"{format_page_marker(2)}\n\n"
+        + ("Page two content. " * 80)
+        + f"\n\n{format_page_marker(5)}\n\n"
+        + ("Page five content. " * 80)
+    )
+    chunks = split_markdown(text, "deck.pdf", 123456789.0)
+
+    assert chunks
+    page_two_chunks = [chunk for chunk in chunks if chunk.page_number == 2]
+    page_five_chunks = [chunk for chunk in chunks if chunk.page_number == 5]
+    assert page_two_chunks
+    assert page_five_chunks
+    assert "Page two content." in page_two_chunks[0].text
+    assert "Page five content." in page_five_chunks[0].text
+
+
+def test_split_markdown_without_markers_uses_unknown_page():
+    text = "This is a test document. " * 100
+    chunks = split_markdown(text, "test_file.md", 123456789.0)
+
+    assert chunks
+    assert all(chunk.page_number == "n/a" for chunk in chunks)
 
 
 def test_split_markdown_generates_stable_chunk_ids():
@@ -17,3 +61,40 @@ def test_split_markdown_generates_stable_chunk_ids():
     ).hexdigest()
     assert first.chunk_id == str(uuid.UUID(hex=expected_hash))
     assert first.document_name == filename
+
+
+def test_chunk_to_md_omits_unknown_page():
+    chunk = Chunk(
+        chunk_id="1",
+        document_name="notes.md",
+        page_number="n/a",
+        last_modified=0.0,
+        text="Some content.",
+    )
+
+    assert chunk.to_md() == "### Source: notes.md\n\nSome content."
+
+
+def test_export_document_markdown_adds_single_page_marker():
+    document = SimpleNamespace(
+        pages={1: object()},
+        export_to_markdown=lambda page_no=None: "Single page body.",
+    )
+
+    markdown = export_document_markdown(document)
+
+    assert markdown == f"{format_page_marker(1)}\n\nSingle page body."
+
+
+def test_export_document_markdown_exports_each_page_separately():
+    document = SimpleNamespace(
+        pages={1: object(), 2: object()},
+        export_to_markdown=lambda page_no=None: f"Body for page {page_no}.",
+    )
+
+    markdown = export_document_markdown(document)
+
+    assert markdown == (
+        f"{format_page_marker(1)}\n\nBody for page 1.\n\n"
+        f"{format_page_marker(2)}\n\nBody for page 2."
+    )


### PR DESCRIPTION
Two parts:
1.
A small bug fix in the install.sh script: it was not possible in the interactive install to select no cloud provider, since leaving it blank would automatically select the default, which is google. Removed the default so that the user has the choice.

2.
chunking.py simply invented page numbers, by setting page_number = index // 5 + 1. With large documents this gets more misleading, and DD users will not find the citations. Docling preserves page provenance so we can carry it through the chunk payload. Docling export now embeds page markers (lib/adapters/docling/converter.py) and Chunking reads those markers.