### PR TITLE
Repair trailing commas in LLM JSON

### DIFF
--- a/lib/json_parser.py
+++ b/lib/json_parser.py
@@ -59,17 +59,74 @@ def _escape_invalid_json_backslashes(json_str: str) -> str:
     return "".join(repaired)
 
 
+def _remove_trailing_json_commas(json_str: str) -> str:
+    """Remove commas before closing objects or arrays, but never inside strings."""
+    repaired = []
+    in_string = False
+    escaped = False
+    i = 0
+
+    while i < len(json_str):
+        char = json_str[i]
+
+        if in_string:
+            repaired.append(char)
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = False
+            i += 1
+            continue
+
+        if char == '"':
+            in_string = True
+            repaired.append(char)
+            i += 1
+            continue
+
+        if char == ",":
+            next_idx = i + 1
+            while next_idx < len(json_str) and json_str[next_idx].isspace():
+                next_idx += 1
+            if next_idx < len(json_str) and json_str[next_idx] in "}]":
+                i += 1
+                continue
+
+        repaired.append(char)
+        i += 1
+
+    return "".join(repaired)
+
+
 def _loads_with_llm_repairs(json_str: str) -> dict | list:
     try:
         return json.loads(json_str)
     except json.JSONDecodeError as first_error:
+        repairs = []
+
         repaired = _escape_invalid_json_backslashes(json_str)
-        if repaired == json_str:
+        if repaired != json_str:
+            repairs.append("invalid backslashes")
+
+        without_trailing_commas = _remove_trailing_json_commas(repaired)
+        if without_trailing_commas != repaired:
+            repairs.append("trailing commas")
+        repaired = without_trailing_commas
+
+        if not repairs:
             raise first_error
         try:
-            return json.loads(repaired)
+            parsed = json.loads(repaired)
         except json.JSONDecodeError:
             raise first_error
+        logger.warning(
+            "Successfully repaired malformed JSON output (%s).",
+            ", ".join(repairs),
+        )
+        return parsed
+
 
 def repair_json_payload(raw_output: str) -> dict | list:
     """Extracts and parses JSON from a raw LLM string."""

--- a/tests/utils/test_json_parser.py
+++ b/tests/utils/test_json_parser.py
@@ -1,3 +1,5 @@
+import pytest
+
 from lib.json_parser import repair_json_payload
 
 
@@ -16,3 +18,63 @@ def test_repair_json_payload_preserves_valid_escapes():
 
     assert result["summary"] == "Line 1\nLine 2"
     assert result["concerns"] == 'Quote: "ok"'
+
+
+def test_repair_json_payload_removes_trailing_comma_from_object():
+    result = repair_json_payload('{"startup_name": "Acme", "rank": 1,}')
+
+    assert result == {"startup_name": "Acme", "rank": 1}
+
+
+def test_repair_json_payload_removes_trailing_comma_from_array():
+    result = repair_json_payload('[{"rank": 1},]')
+
+    assert result == [{"rank": 1}]
+
+
+def test_repair_json_payload_removes_nested_trailing_commas():
+    result = repair_json_payload(
+        '''
+        {
+          "rankings": [
+            {"startup_name": "Acme", "rank": 1,},
+          ],
+        }
+        '''
+    )
+
+    assert result == {
+        "rankings": [{"startup_name": "Acme", "rank": 1}],
+    }
+
+
+def test_repair_json_payload_preserves_comma_sequences_inside_strings():
+    result = repair_json_payload(
+        '{"text": "Keep literal ,} and ,] sequences",}'
+    )
+
+    assert result["text"] == "Keep literal ,} and ,] sequences"
+
+
+def test_repair_json_payload_handles_escaped_quotes_while_removing_comma():
+    result = repair_json_payload(
+        '{"text": "Quote: \\"ok\\", followed by ,}",}'
+    )
+
+    assert result["text"] == 'Quote: "ok", followed by ,}'
+
+
+def test_repair_json_payload_combines_backslash_and_trailing_comma_repairs():
+    result = repair_json_payload(
+        r'{"summary": "Path C:\Program Files\Demo", "status": "OK",}'
+    )
+
+    assert result == {
+        "summary": r"Path C:\Program Files\Demo",
+        "status": "OK",
+    }
+
+
+def test_repair_json_payload_does_not_repair_unquoted_property_names():
+    with pytest.raises(ValueError, match="Expecting property name"):
+        repair_json_payload('{startup_name: "Acme",}')


### PR DESCRIPTION
## What changed

- Repair trailing commas before closing JSON objects and arrays.
- Preserve comma-like sequences inside quoted strings.
- Combine trailing-comma repair with the existing invalid-backslash repair.
- Log successful repairs and keep unsupported malformed JSON visible as errors.
- Add focused regression coverage.

## Why

LLM responses can be otherwise valid JSON but contain a trailing comma. This caused bulk refresh to stop when GPT-5.6 Luna returned a malformed suggested-startups response. The parser should conservatively repair this common syntactic defect without masking structural errors.

## Impact

LLM output with trailing commas can proceed to normal downstream validation. Unquoted property names and other unsupported malformed structures still fail, so errors are not silently swallowed.

## Validation

`/opt/homebrew/Caskroom/miniforge/base/envs/sictic-env/bin/python -m pytest -q tests/utils/test_json_parser.py`

Result: 9 passed.
