### PR TITLE
Cloud Agent env: Docling, Qdrant, OpenAI + OpenRouter

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,5 @@
+{
+  "name": "SICTIC-AI",
+  "install": "bash scripts/cloud-agent-install.sh",
+  "start": "bash scripts/cloud-agent-start.sh"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ __pycache__/
 .storage/
 .storage-mirror/
 .installed-skills/
+.openclaw-skills/
 gdrive-mirror/
 gdrive-sync/.state/
 gdrive-sync/logs/

--- a/lib/adapters/docling/converter.py
+++ b/lib/adapters/docling/converter.py
@@ -42,6 +42,7 @@ def build_converter(*, force_full_page_ocr: bool = False):
     api_key = (
         os.environ.get("VLM_API_KEY")
         or os.environ.get("LLM_API_KEY")
+        or os.environ.get("OPENAI_API_KEY")
         or ""
     )
     headers = {"Authorization": f"Bearer {api_key}"} if api_key else {}

--- a/lib/model_config.py
+++ b/lib/model_config.py
@@ -51,7 +51,8 @@ def llm_endpoint() -> ModelEndpoint:
     return ModelEndpoint(
         model=model,
         base_url=_base_url_for_model(model, _first_env("LLM_BASE_URL")),
-        api_key=_first_env("LLM_API_KEY"),
+        # OPENAI_API_KEY is the common Cloud Agent / provider secret name.
+        api_key=_first_env("LLM_API_KEY", "OPENAI_API_KEY"),
     )
 
 
@@ -60,7 +61,8 @@ def embedding_endpoint() -> ModelEndpoint:
     return ModelEndpoint(
         model=model,
         base_url=_base_url_for_model(model, _first_env("EMBEDDING_BASE_URL")),
-        api_key=_first_env("EMBEDDING_API_KEY"),
+        # OpenRouter embeddings may use EMBEDDING_API_KEY or OPENROUTER_API_KEY.
+        api_key=_first_env("EMBEDDING_API_KEY", "OPENROUTER_API_KEY"),
     )
 
 

--- a/scripts/cloud-agent-install.sh
+++ b/scripts/cloud-agent-install.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Idempotent Cloud Agent bootstrap for SICTIC-AI.
+# Creates/updates the conda env (Docling + deps), installs skills non-interactively,
+# and seeds .env with OpenAI (LLM/VLM) + OpenRouter (embeddings) defaults.
+# Secrets come from the Cloud Agent environment; do not commit .env.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+ensure_conda() {
+  if command -v conda >/dev/null 2>&1; then
+    return
+  fi
+  if [ -x "$HOME/miniforge3/bin/conda" ]; then
+    # shellcheck disable=SC1091
+    eval "$("$HOME/miniforge3/bin/conda" shell.bash hook)"
+    return
+  fi
+  echo "cloud-agent-install: conda not found; installing Miniforge..." >&2
+  curl -fsSL -o /tmp/Miniforge3.sh \
+    "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
+  bash /tmp/Miniforge3.sh -b -p "$HOME/miniforge3"
+  # shellcheck disable=SC1091
+  eval "$("$HOME/miniforge3/bin/conda" shell.bash hook)"
+}
+
+env_set() {
+  local key="$1"
+  local value="$2"
+  local path="$3"
+  local tmp escaped
+  tmp="${path}.tmp.$$"
+  escaped=$(printf '%s' "$value" | sed 's/[\/&]/\\&/g')
+  if grep -q "^[[:space:]]*$key[[:space:]]*=" "$path"; then
+    sed "s/^\\([[:space:]]*$key[[:space:]]*=\\).*/\\1$escaped/" "$path" > "$tmp"
+  else
+    cp "$path" "$tmp"
+    printf '%s=%s\n' "$key" "$value" >> "$tmp"
+  fi
+  mv "$tmp" "$path"
+}
+
+seed_cloud_env() {
+  local env_path="$REPO_ROOT/.env"
+  local template="$REPO_ROOT/.env-template"
+  local skills_target="${INSTALLED_SKILLS_PATH:-$REPO_ROOT/.openclaw-skills}"
+
+  if [ ! -f "$env_path" ]; then
+    cp "$template" "$env_path"
+  fi
+
+  # Paths
+  env_set "REPO_PATH" "$REPO_ROOT" "$env_path"
+  env_set "INSTALLED_SKILLS_PATH" "$skills_target" "$env_path"
+  env_set "LOCAL_STORAGE_PATH" "${LOCAL_STORAGE_PATH:-$REPO_ROOT/.storage}" "$env_path"
+  env_set "LOCAL_DATA_PATH" "${LOCAL_DATA_PATH:-$REPO_ROOT}" "$env_path"
+  env_set "QDRANT_HOST" "${QDRANT_HOST:-http://localhost:6333}" "$env_path"
+
+  # Prefer OpenAI for text/vision; OpenRouter for embeddings (no local Ollama).
+  env_set "LLM_MODEL" "${LLM_MODEL:-openai/gpt-4o-mini}" "$env_path"
+  env_set "LLM_BASE_URL" "${LLM_BASE_URL:-}" "$env_path"
+  env_set "VLM_MODEL" "${VLM_MODEL:-openai/gpt-4o-mini}" "$env_path"
+  env_set "VLM_BASE_URL" "${VLM_BASE_URL:-}" "$env_path"
+  env_set "EMBEDDING_MODEL" "${EMBEDDING_MODEL:-openrouter/openai/text-embedding-3-small}" "$env_path"
+  env_set "EMBEDDING_BASE_URL" "${EMBEDDING_BASE_URL:-}" "$env_path"
+  env_set "RANKED_LLMS" "${RANKED_LLMS:-openai/gpt-4o-mini}" "$env_path"
+  env_set "CLOUD_PROVIDER" "${CLOUD_PROVIDER:-}" "$env_path"
+
+  # Map Cloud Agent secrets into .env when present (never print values).
+  if [ -n "${LLM_API_KEY:-}" ]; then
+    env_set "LLM_API_KEY" "$LLM_API_KEY" "$env_path"
+  elif [ -n "${OPENAI_API_KEY:-}" ]; then
+    env_set "LLM_API_KEY" "$OPENAI_API_KEY" "$env_path"
+  fi
+  if [ -n "${VLM_API_KEY:-}" ]; then
+    env_set "VLM_API_KEY" "$VLM_API_KEY" "$env_path"
+  elif [ -n "${LLM_API_KEY:-}" ]; then
+    env_set "VLM_API_KEY" "$LLM_API_KEY" "$env_path"
+  elif [ -n "${OPENAI_API_KEY:-}" ]; then
+    env_set "VLM_API_KEY" "$OPENAI_API_KEY" "$env_path"
+  fi
+  if [ -n "${EMBEDDING_API_KEY:-}" ]; then
+    env_set "EMBEDDING_API_KEY" "$EMBEDDING_API_KEY" "$env_path"
+  elif [ -n "${OPENROUTER_API_KEY:-}" ]; then
+    env_set "EMBEDDING_API_KEY" "$OPENROUTER_API_KEY" "$env_path"
+  fi
+}
+
+ensure_conda
+seed_cloud_env
+
+SKILLS_TARGET="${INSTALLED_SKILLS_PATH:-$REPO_ROOT/.openclaw-skills}"
+mkdir -p "$SKILLS_TARGET"
+
+# install.sh is interactive by default; Cloud Agents must use --non-interactive.
+./install.sh --non-interactive --target "$SKILLS_TARGET"
+
+# Prefetch the Qdrant binary so start is fast after snapshot (do not leave a
+# process running from install — Cloud Agent start owns the daemon).
+if [ ! -x "$REPO_ROOT/qdrant/qdrant" ]; then
+  ./launch.sh start qdrant
+  ./launch.sh stop qdrant || true
+fi
+
+echo "cloud-agent-install: done (conda env + Docling + skills + Qdrant binary)"

--- a/scripts/cloud-agent-start.sh
+++ b/scripts/cloud-agent-start.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Per-boot Cloud Agent start: bring up Qdrant (Docling is an in-process library).
+# Skips Ollama; embeddings/LLM use OpenRouter/OpenAI via API keys.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+if ! command -v conda >/dev/null 2>&1 && [ -x "$HOME/miniforge3/bin/conda" ]; then
+  # shellcheck disable=SC1091
+  eval "$("$HOME/miniforge3/bin/conda" shell.bash hook)"
+fi
+
+./launch.sh start qdrant
+
+# Wait until Qdrant answers.
+host="${QDRANT_HOST:-http://localhost:6333}"
+for _ in $(seq 1 60); do
+  if curl -fsS "$host/readyz" >/dev/null 2>&1 || curl -fsS "$host/" >/dev/null 2>&1; then
+    echo "cloud-agent-start: qdrant ready at $host"
+    exit 0
+  fi
+  sleep 1
+done
+
+echo "cloud-agent-start: qdrant did not become ready at $host" >&2
+exit 1

--- a/tests/utils/test_model_config.py
+++ b/tests/utils/test_model_config.py
@@ -40,3 +40,27 @@ def test_ollama_endpoint_uses_ollama_host_when_base_url_is_blank(monkeypatch):
 
     assert endpoint.model == "ollama/qwen3:8b"
     assert endpoint.base_url == "http://ollama.example.test:11434"
+
+
+def test_llm_endpoint_falls_back_to_openai_api_key(monkeypatch):
+    monkeypatch.setenv("LLM_MODEL", "openai/gpt-4o-mini")
+    monkeypatch.delenv("LLM_API_KEY", raising=False)
+    monkeypatch.delenv("LLM_BASE_URL", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "openai-secret")
+
+    endpoint = llm_endpoint()
+
+    assert endpoint.api_key == "openai-secret"
+    assert endpoint.base_url is None
+
+
+def test_embedding_endpoint_falls_back_to_openrouter_api_key(monkeypatch):
+    monkeypatch.setenv("EMBEDDING_MODEL", "openrouter/openai/text-embedding-3-small")
+    monkeypatch.delenv("EMBEDDING_API_KEY", raising=False)
+    monkeypatch.delenv("EMBEDDING_BASE_URL", raising=False)
+    monkeypatch.setenv("OPENROUTER_API_KEY", "openrouter-secret")
+
+    endpoint = embedding_endpoint()
+
+    assert endpoint.api_key == "openrouter-secret"
+    assert endpoint.base_url is None


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Sets up a non-interactive Cloud Agent path for SICTIC-AI so we do not rely on the interactive `install.sh` prompts or local Ollama.

### What’s included
- `.cursor/environment.json` with `install` / `start` hooks
- `scripts/cloud-agent-install.sh` — Miniforge/conda `sictic-env` (Docling), skill copy via `install.sh --non-interactive`, `.env` defaults for OpenAI LLM/VLM + OpenRouter embeddings, Qdrant binary prefetch
- `scripts/cloud-agent-start.sh` — starts Qdrant only (no Ollama)
- API key fallbacks: `OPENAI_API_KEY` → LLM/VLM (including Docling picture descriptions), `OPENROUTER_API_KEY` → embeddings

### Secrets still needed (user will add later)
- `LLM_API_KEY` (or `OPENAI_API_KEY`)
- `EMBEDDING_API_KEY` (or `OPENROUTER_API_KEY`)

Environment snapshot / Save is blocked until those keys are present.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019ffb05-ff10-7af8-b3e0-43c31fbe2965?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019ffb05-ff10-7af8-b3e0-43c31fbe2965&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

