### PR TITLE
Fix installer defaults and simplify AI-agent setup

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -29,7 +29,8 @@ RANKED_LLMS="gemini3.1-pro-preview, gemini-3.1-flash-lite, gemma4:31b-nvfp4, qwe
 QDRANT_HOST=http://localhost:6333
 OLLAMA_HOST=http://localhost:11434
 
-# Absolute local application storage path.
+# Absolute local application storage path. The installer suggests
+# <REPO_PATH>/local_storage.
 LOCAL_STORAGE_PATH=
 
 # Absolute local runtime cache path for cache/ and docling_data/.
@@ -38,7 +39,8 @@ LOCAL_DATA_PATH=
 
 # Cloud provider and root. CLOUD_STORAGE_PATH may be a Google Drive folder ID,
 # "root", or a folder path/name such as "SICTIC-AI" or "SICTIC-AI/prod".
-CLOUD_PROVIDER=google
+# Cloud synchronization is opt-in. Set this to google to enable Google Drive.
+CLOUD_PROVIDER=
 CLOUD_STORAGE_PATH=
 
 # (Optional) Google Drive Credentials

--- a/README.md
+++ b/README.md
@@ -4,426 +4,297 @@
 ![License MIT](https://img.shields.io/badge/license-MIT-green.svg)
 ![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)
 
-SICTIC is Switzerland's largest and most active business angel network. It has already connected 1'000+ early-stage startups with 500+ angel investors ([sictic.ch](https://www.sictic.ch)).
+SICTIC is Switzerland's largest and most active angel investor network. It
+brings together more than 500 investors, has hosted more than 1,000 startup
+pitches, and its investor community has helped fund more than 300 Swiss
+technology startups ([sictic.ch](https://www.sictic.ch)).
 
-This is the SICTIC-AI toolkit we use. It is an open-source collection of AI-powered analysis routines (also known as skills) designed to supercharge the startup ecosystem. It is completely free to use and easy to contribute to!
+SICTIC-AI is our open-source collection of AI-assisted startup analysis and
+community workflows, AKA **skills**. The toolkit is free to use and contribute
+to.
 
-This toolkit serves four audiences:
-* **Startups:** Prepare for your first funding round with a dry run of our AI on your data room.
-* **Business Angels:** Automate common assessments in your Due Diligence process.
-* **BA Clubs (like SICTIC):** Automate member engagement, startup selection, DD, and monitoring past transactions.
-* **AI Wizards:** Co-develop and refine the future of early stage funding rounds with us!
+It is designed for:
 
-## Available Skills
+- **Startups:** Review funding materials before approaching investors.
+- **Business angels:** Accelerate common due-diligence assessments.
+- **Angel investor networks:** Support member engagement, startup selection,
+  due diligence, and portfolio monitoring.
+- **AI contributors:** Improve how AI supports early-stage funding.
+
+## Let your coding agent set it up
+
+The easiest way to install and use SICTIC-AI is with a coding agent such as
+Codex, Claude Code, OpenClaw, or Gemini. Start your coding agent and send it the
+following prompt:
+
+```text
+Install SICTIC-AI for me using its default local setup.
+
+Before running commands, ask me exactly one question:
+“Which exact local folder should contain the SICTIC-AI repository?
+For example: /Users/you/SICTIC-AI”
+
+After the initial folder question, ask me again only if:
+- the selected folder cannot be used safely;
+- installing a system prerequisite requires my authorization;
+- the operating system cannot support the default setup; or
+- setup fails and there are multiple materially different ways to proceed.
+
+Do not configure Google Drive, hosted model providers, API keys, or other
+optional integrations. Mention them only after the local installation succeeds.
+
+After I answer, continue autonomously:
+
+1. Check whether the operating system is macOS, Linux, or WSL2.
+2. Check the tools needed to clone the repository:
+   - on macOS, first check whether Homebrew is installed, then check Git;
+     install either one if missing
+   - on Ubuntu, Debian, or WSL2, check Git, curl, and wget; install any that are
+     missing using apt
+3. Clone https://github.com/ducroo/SICTIC-AI into the folder I selected. If
+   that folder already contains the correct repository, reuse it after
+   verifying its Git remote. Never overwrite an unrelated or modified folder.
+4. Read README.md and follow its “Quick manual setup” section in sequence.
+5. Check for Miniforge/Conda and Ollama. Install either one if missing using the
+   documented platform commands.
+6. Run the installer without copying skills to an agent skills directory, using
+   these defaults:
+   - REPO_PATH: the selected repository folder
+   - LOCAL_STORAGE_PATH: <REPO_PATH>/local_storage
+   - LOCAL_DATA_PATH: <REPO_PATH>
+   - no cloud provider
+   - accept the installer's default local models, URLs, and service settings
+7. Start Ollama and Qdrant with ./launch.sh start and confirm that both services
+   are running. Allow the launcher to pull configured Ollama models that are
+   missing, but do not delete or reinstall models that are already present.
+8. Run the test suite and the skill harness help command to verify the setup.
+9. Report what was installed, the important paths, and one example command for
+   running a user-facing skill.
+
+Do not modify tracked repository source files as part of installation.
+```
+
+This prompt deliberately installs local models, so it does not require an API
+account or send startup data to a hosted LLM provider.
+
+### Switching models
+
+The bundled local models make the default installation widely accessible, but
+more capable models are available if your hardware or budget permits. Local
+options include the [Gemma 4](https://ollama.com/library/gemma4) and
+[Qwen 3.6](https://ollama.com/library/qwen3.6) families through Ollama; cloud
+options include `gpt-5.6-luna` through the OpenAI API. Larger local models
+generally require substantially more memory and disk space.
+
+The example below switches text generation to OpenAI while retaining the local
+vision and embedding models. Other local models and cloud providers follow a
+similar route: select the model and configure its endpoint and API key when
+required.
+
+To use `gpt-5.6-luna`:
+
+1. Create an account at [platform.openai.com](https://platform.openai.com/),
+   configure billing, and create an
+   [API key](https://platform.openai.com/api-keys).
+2. Replace these values in `.env`:
+
+```dotenv
+LLM_MODEL=openai/gpt-5.6-luna
+LLM_BASE_URL=
+LLM_API_KEY=your-api-key
+```
+
+Treat the API key like a password: never commit or share your `.env` file. The
+model name and API-key workflow are documented in the
+[official OpenAI model documentation](https://developers.openai.com/api/docs/models/gpt-5.6-luna)
+and [API quickstart](https://platform.openai.com/docs/quickstart).
+
+### Running skills with the agent
+
+Once installed, the agent can run skills for you. For example: “Run
+`startup_profile` for SpaceX” or “Ask the `spacex` dataset about its main
+technical risks.” See [Running a skill](#running-a-skill) below for direct
+command-line usage.
+
+## Contributing
+
+Help us turn strong investing practice into open, reusable skills. Critical
+thinking and practical investing experience are the differentiators; being an
+AI wizard is not a requirement.
+
+We develop skills in teams and meet regularly to challenge assumptions, compare
+results, and improve the workflows. By establishing shared standards for
+early-stage investing, we aim to structurally strengthen the startup ecosystem
+in Switzerland and Europe. Join us with your experience, questions, and ideas.
+
+## Quick manual setup
+
+SICTIC-AI requires macOS, Linux, or WSL2, plus Git, Miniforge, and Ollama.
+Ollama is required for the default local models. Install the prerequisites for
+your platform first.
+
+On macOS:
+
+```bash
+# Install Homebrew first if `brew` is not available:
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+brew install --cask miniforge
+conda init zsh
+exec $SHELL
+brew install ollama
+```
+
+On Ubuntu, Debian, or WSL2:
+
+```bash
+sudo apt update && sudo apt install -y git curl wget
+wget "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
+bash Miniforge3-*.sh
+conda init bash
+exec $SHELL
+curl -fsSL https://ollama.com/install.sh | sh
+```
+
+Then clone the repository and run the installer:
+
+```bash
+git clone https://github.com/ducroo/SICTIC-AI.git
+cd SICTIC-AI
+./install.sh
+./launch.sh start
+./launch.sh status
+```
+
+The installer creates or updates the `sictic-env` Conda environment and helps
+configure `.env`. It also asks for `INSTALLED_SKILLS_PATH`: the optional
+directory into which it copies skills for discovery by your coding agent.
+
+- Choose `none` to work directly from the repository without copying skills.
+- Enter an absolute path to make SICTIC-AI skills discoverable by that agent.
+
+For the default local setup:
+
+- Set `REPO_PATH` to `/Users/you/SICTIC-AI`, replacing it with the folder where
+  you put the repository.
+- Accept the suggested local storage and data paths.
+- Choose `none` for `INSTALLED_SKILLS_PATH`.
+- Choose `none` for `CLOUD_PROVIDER`.
+- Accept the local Ollama model, URL, and service defaults.
+
+The installer writes these choices to `.env`.
+
+Repository-only mode still supports all commands documented below. Re-run the
+installer after editing or adding skill instructions if you use copied skills.
+
+The commands above are sufficient for the default local setup. For hosted model
+providers, Google Drive synchronization, advanced command interfaces, and
+maintenance tasks, see
+[Installation and operations](docs/installation-and-operations.md).
+
+## Configuration paths
+
+The installer suggests sensible values for a new `.env`:
+
+| Variable | What it controls | Example |
+|---|---|---|
+| `REPO_PATH` | Root of this Git repository and its source code | `/Users/you/SICTIC-AI` |
+| `INSTALLED_SKILLS_PATH` | Optional directory receiving agent-discoverable copies of skills | `none` or `/Users/you/.claude/skills` |
+| `LOCAL_STORAGE_PATH` | Local root containing startup, community, and generated datasets and insights | `/Users/you/SICTIC-AI/local_storage` |
+| `CLOUD_STORAGE_PATH` | Optional cloud equivalent of `LOCAL_STORAGE_PATH`, currently a Google Drive folder ID, `root`, or path/name | `SICTIC-AI-storage` |
+| `LOCAL_DATA_PATH` | Machine-local root under which `cache/` and `docling_data/` are stored | `/Users/you/SICTIC-AI` |
+| `CLOUD_PROVIDER` | Optional synchronization backend | blank or `google` |
+
+All skills operate on `LOCAL_STORAGE_PATH`. Cloud storage is synchronized to
+that folder by a separate utility; skills do not access Google Drive directly.
+Model and service variables are explained in `.env-template` and in the
+[operations guide](docs/installation-and-operations.md).
+
+## Running a skill
+
+Ask your coding agent, or use the command harness directly:
+
+```bash
+conda run -n sictic-env python -m skills.harness /startup_profile SpaceX
+conda run -n sictic-env python -m skills.harness /dataset_chat SpaceX "What are the main risks?"
+conda run -n sictic-env --no-capture-output python -m skills.harness
+```
+
+Run `/help` in the interactive harness to see available commands. Some
+administrative skills use their own `python -m skills.<name>` interface; their
+`SKILL.md` files and the operations guide show the supported syntax.
+
+## User-facing skills
+
+✅ means available. 🚧 means work in progress. ◻️ means planned but not started.
+Internal building blocks are intentionally omitted.
 
 | Skill | Status | Description |
 |---|---|---|
 | **Community** | | |
-| `expert_search` | ✅ | Identifies club members with relevant domain expertise for due diligence or operational support |
-| `potential_investors` | ✅ | Identifies potential investors for a startup with the strongest fit |
-| `advocates` | ✅ | Identifies inspiring members to represent the organization at external events |
-| `investor_profile` | ✅ | Combines each member's professional profile with their investment track record and preferences |
-| `suggested_startups` | ✅ | Proposes attractive startups in active fundraising to each member |
-| **Startup Selection & Jury** | | |
-| `submission_ready` | ✅ | Checks whether a Dealum application is complete and meets initial SICTIC eligibility criteria |
-| `pitch_ready` | | Evaluates the clarity and completeness of startup materials for investor pitch sessions |
-| **Due Diligence** | | |
-| `startup_profile` | ✅ | Generates a succinct overview of the startup and serves as input for other skills |
-| `team_profile` | ✅ | Assesses individual founders and overall team dynamics |
-| `person_profile` | ✅ | Generates a comprehensive profile for any founder, member, or other person in a dataset |
-| `startup_traction` | ✅ | Summarizes and quantifies the startup's market traction |
-| `dd_checks` | ✅ | Executes a comprehensive suite of common due diligence checks |
-| `market_review` | | Analyzes market size, customer needs, competition, and substitutes |
-| `t&c_review` | | Reviews and assesses the terms and conditions of a proposed funding round |
-| **Ongoing Monitoring** | | |
-| `alerts&news` | | Monitors and interprets relevant news and updates concerning portfolio startups |
-| `startup_support` | | Coordinates operational support provided to startups by investors |
-| `portfolio_mgmt` | | Generates risk-return overviews and performance metrics for startup portfolios |
-| **Operations** | | |
-| `gdrive_sync` | ✅ | Synchronizes local storage with Google Drive |
-| `bulk_refresh` | ✅ | Refreshes one or more insights across one or more datasets |
-| `dataset_maintenance` | ✅ | Diagnoses, migrates, prunes, and repairs datasets and Qdrant collections |
-| `startup_website_import` | ✅ | Imports startup public websites into dataset website folders |
-| `linkedin_maintenance` | ✅ | Lists missing LinkedIn profiles, imports manually scraped profiles, and diagnoses registry issues |
-
-
-<details>
-<summary>▶ Click to see a sample Startup Profile output for SpaceX</summary>
-
-```markdown
-# Startup Profile: SpaceX
-
-1. **Oneliner:** Design, manufacture, and launch of advanced rockets and spacecraft.
-2. **Core industry:** Aerospace Manufacturing and Space Transportation Services.
-3. **Technology:** Highly verticalized manufacturing of reusable launch vehicles (Falcon 9, Starship); significant reliance on complex materials science, extreme-environment engineering, and proprietary autonomous landing software. Technical single point of failure lies in the unproven orbital refueling and heat shield viability of the Starship platform.
-4. **Business model:** B2B/B2G payload launch services (commercial satellites, NASA/DoD contracts) and B2C direct-to-consumer satellite internet (Starlink). Structural risks include astronomical capital expenditure requirements, reliance on favorable government regulatory environments, and the inherent binary risk of catastrophic mission failures destroying hardware and client payloads.
-5. **Current challenges:** Scaling Starship production to achieve promised launch cadence and cost-reduction; navigating intense FAA environmental and launch licensing scrutiny; proving the economic viability of the Starlink constellation against hardware degradation timelines. Expert due diligence required on Starship payload capacities and orbital refueling logistics.
-```
-</details>
-
-
-## Contributing
-
-The setup is deliberately simple so everyone can join and co-develop:
-* This is about investing expertise and insight, not IT know-how.
-* You can safely create new skills or edit existing ones directly inside your UI.
-* Your AI coding agent can review the changes and use its Git integration to
-  publish them to GitHub.
-
-## Runtime Context
-
-The toolkit requires a Unix environment (**macOS, Linux, or WSL2**) and an AI Agent
-(like **OpenClaw, Claude Code, Codex, or Gemini Spark**) to converse with the skills.
-We primarily develop using macOS and OpenClaw, but the architecture is OS-agnostic.
-
-## Quickstart Setup
-
-Five steps to get the toolkit working on your machine:
-
-### Step 1: Install Prerequisites
-
-You need a package manager and Conda to handle the Python environment.
-
-**macOS (using Homebrew):**
-```bash
-brew install --cask miniforge
-conda init zsh        # or `conda init bash`, depending on your terminal
-exec $SHELL           # reload your terminal
-```
-
-**Linux / WSL2 (Ubuntu):**
-```bash
-sudo apt update && sudo apt install -y curl wget
-wget "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
-bash Miniforge3-*.sh  # Follow the prompts, say 'yes' to init
-exec $SHELL           # reload your terminal
-```
-
-Install **Ollama** if you want to use local `ollama/...` models. Local models
-are our default in `.env-template` and are useful for heavy document parsing.
-* **macOS:** `brew install ollama`
-* **Linux/WSL2:** `curl -fsSL https://ollama.com/install.sh | sh`
-
-Qdrant is required for semantic search. You do not need to install it manually:
-`./launch.sh start` downloads the matching Qdrant binary for macOS or Linux into
-`./qdrant/` and starts it with local storage in `./qdrant_data/`.
-
-### Step 2: Install the Environment
-
-Run the provided installer. This creates a self-contained Python environment
-(`sictic-env`) and copies the skill folder contents into your AI workspace.
-The installer registers the repository root in the Conda environment, so
-harness commands execute the current repo code. Re-run the installer after
-changing skill instructions or adding/removing skills. All runtime dependencies
-are defined in `environment.yml`.
-
-```bash
-# Same for macOS, Linux, and WSL2
-./install.sh
-```
-
-The installer creates the conda environment `sictic-env` for macOS, Linux, and
-WSL2. `skills.dataset_chat` uses Docling for document ingestion, with:
-* Apple Vision OCR through `ocrmac` on macOS.
-* RapidOCR on Linux/WSL2.
-
-### Step 3: Configuration
-
-The installer creates `.env` from `.env-template` if needed and prompts for the
-runtime values. Press Enter to accept the value shown in brackets. You need to
-configure these variables:
-
-| \# | Variable | Purpose | Example |
-|---|---|---|---|
-|1| `INSTALLED_SKILLS_PATH` | Deployment-only path for installer-copied skills; development happens in `REPO_PATH` | `/Users/you/.openclaw/workspace-ops/skills` |
-|2| `REPO_PATH` | Absolute path to the root of this SICTIC-AI git repository | `/Users/you/SICTIC-AI` |
-|3| `LOCAL_STORAGE_PATH` | Absolute local application storage path | `/Users/you/SICTIC-AI/gdrive-mirror` |
-|4| `LOCAL_DATA_PATH` | Absolute local runtime cache path for `cache/` and `docling_data/` | `/Users/you/SICTIC-AI` |
-|5| `CLOUD_PROVIDER` | Optional cloud backend; currently only`google` works | `google` |
-|6| `CLOUD_STORAGE_PATH` | Cloud root, such as a Drive folder ID, `root`, or folder path/name | `SICTIC-AI-storage` |
-|7| `LLM_MODEL` | The primary text-generation model used for analysis | `google/gemini-flash-latest` or `ollama/qwen3:8b` |
-|8| `LLM_BASE_URL` | Base URL for the text-generation endpoint; blank uses the provider default | `http://localhost:11434` |
-|9| `LLM_API_KEY` | API key for the text-generation endpoint when needed | blank for local Ollama |
-|10| `VLM_MODEL` | The model used for extracting text from images/charts | `ollama/qwen3-vl:8b` or `openai/gpt-4o-mini` |
-|11| `VLM_BASE_URL` | Base URL for the vision-language endpoint; defaults to `LLM_BASE_URL` | `http://localhost:11434` |
-|12| `VLM_API_KEY` | API key for the vision-language endpoint; defaults to `LLM_API_KEY` | blank for local Ollama |
-|13| `EMBEDDING_MODEL` | The model used for semantic search embeddings | `ollama/qwen3-embedding:8b` or `openai/text-embedding-3-small` |
-|14| `EMBEDDING_BASE_URL` | Base URL for the embedding endpoint; blank uses the provider default | `http://localhost:11434` |
-|15| `EMBEDDING_API_KEY` | API key for the embedding endpoint when needed | blank for local Ollama |
-|16| `RANKED_LLMS` | If insights md files were created with several models, the preferred ranking for re-use. (CSV list) | see `.env-template` |
-
-*(Note: The other variables in `.env-template` are explained inline. You don't need to change them).*
-
-`REPO_PATH` points to this git repository. `INSTALLED_SKILLS_PATH` points to
-the installed skill-copy directory used by the AI workspace for skill discovery.
-Legacy aliases such as `REPO_DIR`, `WORKSPACE_PATH`, `WORKSPACE_DIR`, `STORAGE_PROVIDER`,
-`STORAGE_PATH`, and `STORAGE_MIRROR_PATH` are no longer used; the installer
-removes them from `.env` when it runs.
-
-### Step 4: Start Background Services
-
-SICTIC-AI relies on Qdrant for semantic search and on Ollama when any configured
-model starts with `ollama/`. The launcher downloads Qdrant when needed, starts
-Qdrant and Ollama, and pulls the Ollama models referenced by `LLM_MODEL`,
-`EMBEDDING_MODEL`, and `VLM_MODEL` if they are not already available.
-
-```bash
-./launch.sh start
-./launch.sh status  # check running services
-./launch.sh stop    # shut down local background services
-```
-
-### Step 5: Run a Skill
-
-You are ready to go. There are two common ways to execute skills:
-
-1. Use the lightweight slash-command harness for user-facing commands exposed by
-   `skills.harness`.
-2. Run a skill module directly when you need that module's own CLI options or
-   when the command is an operational utility.
-
-```bash
-conda run -n sictic-env python -m skills.harness /startup_profile SpaceX
-conda run -n sictic-env python -m skills.dataset_chat SpaceX "What are the main risks?"
-```
-
-The harness also has an interactive mode. When launching it through
-`conda run`, use `--no-capture-output`; otherwise Conda may close stdin and the
-prompt exits immediately.
-
-```bash
-conda run -n sictic-env --no-capture-output python -m skills.harness
-```
-
-Alternatively, activate the environment first and then run:
-
-```bash
-conda activate sictic-env
-python -m skills.harness
-```
-
-Inside the harness, run `/help` to list commands such as
-`/dataset_chat <dataset> <question>`, `/startup_profile <startup>`, and
-`/dd_checks <startup>`.
-
-### Command interfaces
-
-Use these supported entry points:
-
-| Interface | Purpose | Example |
-|---|---|---|
-| Harness one-shot | Run one user-facing slash command and exit | `conda run -n sictic-env python -m skills.harness /startup_profile SpaceX` |
-| Harness interactive | Start the slash-command REPL for manual testing | `conda run -n sictic-env --no-capture-output python -m skills.harness` |
-| Skill module | Run one module's direct CLI and options | `conda run -n sictic-env python -m skills.bulk_refresh --dataset spacex --skill startup_profile` |
-| Dataset maintenance | Maintained operational utility | `conda run -n sictic-env python -m skills.dataset_maintenance dataset-from-insight --target-dataset sictic-members-investor-profile --source-datasets sictic-members --skill investor_profile` |
-| Script | Maintenance or migration operation documented by that script | `conda run -n sictic-env python scripts/generate_member_profiles.py --help` |
-
-Use the harness when the command exists in `/help` and you want the stable,
-user-facing behavior. Harness commands always start with `/`, for example
-`/startup_profile SpaceX`; plain `startup_profile SpaceX` is rejected.
-
-Use direct module execution as `python -m skills.<skill_name>` when the skill has
-its own CLI flags, when it is not exposed by `/help`, or when the operation is a
-batch or maintenance workflow. For example, `skills.bulk_refresh` is usually run
-directly because its module CLI owns options such as `--dataset` and `--skill`.
-
-## Using it in practice
-
-### 1. Community management
-
-Communities can be large, so it is useful to do some preparation overnight.
-
-To make an inventory of all persons mentioned in `community/sictic-members/datasets/`, run:
-
-```bash
-conda run -n sictic-env python -c "from skills.person_profile.persons_in_dataset import persons_in_dataset; persons_in_dataset('sictic-members')"
-```
-
-It will generate a draft of all members in `community/sictic-members/insights/persons-in-dataset-sictic-members-manual.md`. Probably it is quite incomplete and you want to edit it manually. From there on, the system will use that list of members.
-
-Next you want to create a comprehensive profile of each member combining their LinkedIn profile, their resumes and other credentials. For this you use:
-
-```bash
-conda run -n sictic-env python -m skills.person_profile --dataset sictic-members
-```
-
-The resulting profiles are in:
-
-```text
-storage/community/sictic-members/insights/person-profile/
-```
-
-It may report LinkedIn profiles that require manual scraping. Use:
-
-```bash
-python -m skills.linkedin_maintenance missing
-python -m skills.linkedin_maintenance import profiles.json
-python -m skills.linkedin_maintenance diagnose
-```
-
-The import command uses the pending registry to route each profile to its
-dataset. An explicit `--dataset` may be supplied as an additional target.
-
-The matching skills `expert_search`, `potential_investors`, and `advocates`
-search a derived `sictic-members-investor-profile` dataset for the best fit. Its
-documents combine professional profiles with investment track records and
-preferences.
-
-```bash
-conda run -n sictic-env python -m skills.investor_profile
-conda run -n sictic-env python -m skills.dataset_maintenance dataset-from-insight --target-dataset sictic-members-investor-profile --source-datasets sictic-members --skill investor_profile
-```
-
-### 2. Overnight Refresh
-
-The `bulk_refresh` command can refresh a set of insights on a set of datasets.
-* If the datasets are not specified, it will refresh all skills with a `__active_dataset__.md` file in the dataset subfolder.
-* If the insights are not specified, it will refresh all relevant skills.
-
-```bash
-# refresh the person_profile on spacex
-conda run -n sictic-env python -m skills.bulk_refresh --skill person_profile --dataset spacex
-# refresh all insights on spacex
-conda run -n sictic-env python -m skills.bulk_refresh --dataset spacex
-# refresh all the person_profile for all active dataset
-conda run -n sictic-env python -m skills.bulk_refresh --skill person_profile
-# refresh all insights on all active dataset
-conda run -n sictic-env python -m skills.bulk_refresh
-
-```
+| `expert_search` | ✅ | Finds members with relevant domain expertise for due diligence or operational support. |
+| `potential_investors` | ✅ | Finds investors with the strongest fit for a startup. |
+| `advocates` | ✅ | Finds members suited to representing the organization at external events. |
+| `investor_profile` | ✅ | Combines a member's professional profile, investment record, and preferences. |
+| `suggested_startups` | ✅ | For each investor, shortlists matching startups that are actively fundraising. |
+| **Startup selection and jury** | | |
+| `submission_ready` | 🚧 | Checks whether a Dealum application is complete and meets initial eligibility criteria. |
+| `pitch_ready` | 🚧 | Assesses whether a startup is mature enough and ready to pitch at a SICTIC event. |
+| **Due diligence** | | |
+| `dataset_chat` | ✅ | Answers evidence-based questions about a startup or community dataset. |
+| `startup_profile` | ✅ | Produces a concise, neutral overview used by other skills. |
+| `team_profile` | ✅ | Assesses founders and the overall team. |
+| `person_profile` | ✅ | Creates a comprehensive profile of a founder, member, or other person. |
+| `startup_traction` | ✅ | Summarizes and quantifies commercial traction. |
+| `dd_checks` | ✅ | Runs a broad suite of due-diligence checks. |
+| `dd_priorities` | ✅ | Extracts the 3 to 8 most decision-relevant priorities from `dd_checks`. |
+| `startup_website_import` | ✅ | Imports a startup's public website into its due-diligence dataset. |
+| `market_review` | ◻️ | Reviews market size, customer needs, competition, and substitutes. |
+| `sha_review` | 🚧 | Reviews shareholders' agreements, investment terms and conditions, and capitalization tables. |
+| `companyresearch.ch` | 🚧 | Uses the companyresearch.ch API to collect publicly available information about a startup. |
+| **Ongoing monitoring** | | |
+| `alerts_and_news` | ◻️ | Monitors and interprets relevant portfolio-company news and updates. |
+| `startup_support` | ◻️ | Coordinates operational support from investors. |
+| `portfolio_mgmt` | ◻️ | Produces portfolio risk, return, and performance overviews. |
+| **Data and operations** | | |
+| `dealum_import` | ✅ | Imports the application dossier of a startup from the Dealum.com platform using an API key. |
+| `gdrive_sync` | ✅ | Synchronizes local storage with Google Drive when enabled. |
+| `bulk_refresh` | ✅ | Refreshes selected insights across selected datasets. |
+| `dataset_maintenance` | ✅ | Diagnoses, migrates, prunes, and repairs datasets and search indexes. |
+| `linkedin_maintenance` | ✅ | Finds missing LinkedIn profiles and imports manually collected profiles. |
 
 ## Where is my data?
 
-Once configured, the system uses the storage domains defined in
-`config/storage_domains.json`. The default layout is:
+Application data is rooted at `LOCAL_STORAGE_PATH`; runtime-only data is rooted
+at `LOCAL_DATA_PATH`.
 
 | Path | Description |
 |---|---|
-| `storage/startups/<startup>/datasets/` | Raw startup data rooms, such as pitch decks, Excel sheets, and PDFs. |
-| `storage/startups/<startup>/insights/` | Generated startup Markdown reports. |
-| `storage/community/<dataset>/datasets/` | Primary community and member datasets, such as `sictic-members`. |
-| `storage/community/<dataset>/insights/` | Generated community Markdown reports and profiles. |
-| `storage/generated/<dataset>/datasets/` | Searchable datasets assembled from insights, such as `sictic-members-investor-profile`. |
-| `storage/generated/<dataset>/insights/` | Insights associated with generated datasets, when applicable. |
-| `docling_data/datasets2md/<domain>/<dataset>/datasets/` | Durable machine-local parsed Markdown generated by Docling. This is not synchronized to Google Drive. |
-| `storage/<domain>/<dataset>/insights/persons-in-dataset-<dataset>-manual.md` | Manually maintained person lists generated by `persons_in_dataset`. |
-| `gdrive_sync_state/<pairing-id>/` | Durable Google Drive synchronization baseline and changes token. Do not delete this as part of cache cleanup. |
-| `cache/...` | Disposable runtime cache and temporary operational state. |
+| **`<LOCAL_STORAGE_PATH>/storage/startups/<startup_name>/`** | **The collection of information about a single startup.** |
+| ↳ `./datasets/` | Startup data room: pitch decks, spreadsheets, PDFs, website imports, and other source material. |
+| ↳ `./insights/` | Generated startup reports. |
+| **`<LOCAL_STORAGE_PATH>/storage/community/<community_name>/`** | **A community or member collection, such as `sictic-members`.** |
+| ↳ `./datasets/` | Community and member source data. |
+| ↳ `./insights/` | Generated community reports and profiles. |
+| **`<LOCAL_STORAGE_PATH>/storage/generated/<dataset_name>/`** | **A searchable dataset assembled from generated insights.** |
+| ↳ `./datasets/` | Materialized source documents for the generated dataset. |
+| ↳ `./insights/` | Reports associated with the generated dataset. |
+| **`<LOCAL_DATA_PATH>/`** | **Machine-local parsed data and disposable runtime data.** |
+| ↳ `./docling_data/` | Durable parsed documents; not synchronized to cloud storage. |
+| ↳ `./cache/` | Disposable runtime cache and temporary state. |
+| `<REPO_PATH>/gdrive_sync_state/` | Durable Google Drive synchronization state; do not delete as cache. |
 
-`LOCAL_DATA_PATH` optionally changes the root containing `cache/` and
-`docling_data/`. It defaults to `REPO_PATH`.
+For example, place a pitch deck in
+`<LOCAL_STORAGE_PATH>/storage/startups/spacex/datasets/`. Running
+`startup_profile` writes its result below
+`<LOCAL_STORAGE_PATH>/storage/startups/spacex/insights/`.
 
-If you put a pitch deck into `storage/startups/spacex/datasets/`, running the
-`startup_profile` skill will parse it, index it, and write the final analysis
-to `storage/startups/spacex/insights/`.
+## Where to learn more
 
-Document parsing is handled locally by Docling. On macOS, the installer includes
-the `ocrmac` extra for Apple Vision OCR. On Linux/WSL2, the installer uses the
-standard Docling package and RapidOCR. In both cases, `VLM_MODEL` is used for
-image and chart descriptions through Ollama or another configured model provider.
-RTF files, which Docling does not support, are converted directly to searchable
-plain text using the Conda `striprtf` package.
+The `docs/` folder currently contains:
 
-## Test suite
-
-Run the local test suite with:
-
-```bash
-conda run -n sictic-env python -m pytest -q
-```
-
-The default suite uses isolated local storage and mocked external services.
-Tests marked `live` are collected but skipped.
-
-To run only the opt-in live tests:
-
-```bash
-SICTIC_RUN_LIVE_SMOKE=1 conda run -n sictic-env python -m pytest -q -m live
-```
-
-Live tests may require running Qdrant and Ollama services and specific test
-datasets. Tests whose required datasets are unavailable are skipped.
-
-## Google Drive Integration
-
-All skills read and write the local filesystem path configured by
-`LOCAL_STORAGE_PATH`. Google Drive access is isolated in the standalone
-`gdrive_sync` administrative utility under `gdrive-sync/`; normal application
-storage never accesses Drive.
-
-In production at SICTIC, Google Drive is used to share datasets and insights
-with Deal Leads. `CLOUD_PROVIDER=google` enables synchronization and
-`CLOUD_STORAGE_PATH` identifies the Drive root.
-
-**Setting up the Google Drive API requires creating an OAuth Desktop-App client in the Google Cloud Console.** Because this process involves navigating complex Google Cloud settings and handling JSON credentials, the best approach is to ask your AI assistant to walk you through the Google Cloud setup and authenticate the credentials for you (We did it with Openclaw)
-
-#### Google Drive Synchronization
-
-Synchronizing a large cloud drive is tedious and slow. SICTIC-AI therefore
-works entirely against `LOCAL_STORAGE_PATH`, tracks changes on both sides, and
-synchronizes periodically instead of accessing Google Drive for every file
-operation.
-
-| Command | Description |
-|---|---|
-| `python -m gdrive_sync pull` | Make local storage match Google Drive. Cloud is authoritative. Use this to create the initial local copy and synchronization baseline. |
-| `python -m gdrive_sync sync --conflict-policy local-wins` | Synchronize changes in both directions. If the same path changed on both sides, keep the local version as canonical. |
-| `python -m gdrive_sync sync --conflict-policy cloud-wins` | Merge cloud changes into local storage. Cloud adds and updates overwrite or create local files. Nothing is deleted on either side. |
-
-Add `--dry-run` to any command to report the planned changes without modifying
-local files, Google Drive, or the successful synchronization baseline. Add
-`--json` when machine-readable output is useful.
-
-Google Drive shortcuts are not supported inside the synchronized root.
-Synchronization preflights for shortcuts and stops before applying changes;
-replace any shortcut with a real folder or file before retrying.
-
-The normal routine is:
-
-1. **Initial setup:** run `python -m gdrive_sync pull`. The first pull
-   walks the complete Drive tree and builds the baseline, so it can take
-   substantial time. (read: hours)
-2. **Before a job:** run
-   `python -m gdrive_sync sync --conflict-policy cloud-wins`. This downloads
-   cloud adds and updates locally without deleting files on either side.
-3. **Run the job:** skills read and write only `LOCAL_STORAGE_PATH`; they do not
-   synchronize while the job is running.
-4. **After a job:** run
-   `python -m gdrive_sync sync --conflict-policy local-wins`.
-
-Later synchronizations are faster because `gdrive_sync` compares local hashes
-with its stored baseline and uses the Google Drive Changes API instead of
-rebuilding the complete inventory each time.
-
-Synchronization is manual today. Automatic synchronization around skill jobs
-is planned but has not yet been implemented.
-
-The command reads these `.env` values:
-
-* `CLOUD_PROVIDER`: must be `google`
-* `LOCAL_STORAGE_PATH`: local application storage root
-* `CLOUD_STORAGE_PATH`: Google Drive folder ID/root
-* `GDRIVE_CREDENTIALS`: OAuth Desktop-App credentials JSON
-* `GDRIVE_TOKEN`: cached OAuth token JSON
-
-Configuring Google OAuth and Drive access is outside the scope of this README.
-Ask a chatbot for help; Gemini was used to configure the current installation.
-
-The durable baseline and Drive changes token are stored under
-`gdrive_sync_state/<pairing-id>/`. Do not delete this directory as cache.
-Runtime logs are written to `logs/gdrive-sync.log`.
-
-## Dataset Maintenance
-
-Dataset ingestion owns document replacement and removal decisions. Qdrant
-adapters perform database operations only. Collection diagnostics and pruning
-are exposed separately:
-
-```bash
-python -m skills.dataset_maintenance diagnose
-python -m skills.dataset_maintenance prune
-python -m skills.dataset_maintenance prune --apply
-python -m skills.dataset_maintenance migrate-startup-dossiers
-```
-
-Pruning is dry-run by default.
+- [Installation and operations](docs/installation-and-operations.md): detailed
+  installer modes, environment and model configuration, background services,
+  command interfaces, Google Drive synchronization, maintenance, and tests.
+- [Codebase assessment](docs/codebase-assessment.md): technical architecture
+  findings, known risks, and recommended follow-up work for contributors.

--- a/docs/installation-and-operations.md
+++ b/docs/installation-and-operations.md
@@ -1,0 +1,186 @@
+# Installation and operations
+
+This guide contains the detailed setup and operational material intentionally
+kept out of the main README.
+
+## Runtime requirements
+
+SICTIC-AI supports macOS, Linux, and WSL2. It requires Conda and is designed to
+be used with a coding agent such as OpenClaw, Claude Code, Codex, or Gemini.
+
+### Install Miniforge
+
+On macOS:
+
+```bash
+brew install --cask miniforge
+conda init zsh                 # or bash
+exec $SHELL
+```
+
+On Ubuntu or WSL2:
+
+```bash
+sudo apt update && sudo apt install -y curl wget
+wget "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-$(uname)-$(uname -m).sh"
+bash Miniforge3-*.sh
+exec $SHELL
+```
+
+Install Ollama if you plan to use the local `ollama/...` models provided as the
+defaults in `.env-template`:
+
+```bash
+# macOS
+brew install ollama
+
+# Linux or WSL2
+curl -fsSL https://ollama.com/install.sh | sh
+```
+
+Qdrant does not require a separate installation. `./launch.sh start` downloads
+the matching binary into `qdrant/` and uses `qdrant_data/` for its local data.
+
+## Run the installer
+
+```bash
+./install.sh
+```
+
+The installer creates or updates the `sictic-env` Conda environment, registers
+the repository on its Python import path, optionally copies skills into an
+agent's skills directory, and configures `.env`.
+
+Use repository-only mode if you do not want copied skills. At the installed
+skills prompt, enter `none` or accept `[none]`. You can still invoke every skill
+through the repository's Python commands.
+
+Useful options:
+
+```bash
+./install.sh --target /absolute/path/to/agent/skills
+./install.sh --rebuild-env
+./install.sh --skip-env
+./install.sh --non-interactive
+```
+
+Re-run the installer after changing `SKILL.md` files if you use copied skills.
+
+## Environment configuration
+
+The main path variables are documented in the README. Other important groups
+are:
+
+- `LLM_*`: primary text-generation model, endpoint, and API key.
+- `VLM_*`: image and chart interpretation model, endpoint, and API key.
+- `EMBEDDING_*`: semantic-search embedding model, endpoint, and API key.
+- `QDRANT_HOST`: Qdrant service URL.
+- `OLLAMA_HOST`: local Ollama service URL.
+- `RANKED_LLMS`: preferred model order when reusing existing insights.
+
+The complete set and its local defaults are in `.env-template`.
+
+Cloud storage is optional. With blank `CLOUD_PROVIDER`, skills use only local
+storage and the installer skips Google Drive configuration. Set
+`CLOUD_PROVIDER=google` to enable the standalone synchronization utility.
+
+## Background services
+
+```bash
+./launch.sh start
+./launch.sh status
+./launch.sh stop
+```
+
+The launcher starts Qdrant and, when an `ollama/...` model is configured,
+Ollama. It also pulls missing models referenced by `LLM_MODEL`, `VLM_MODEL`, and
+`EMBEDDING_MODEL`.
+
+## Command interfaces
+
+Use the harness for stable user-facing slash commands:
+
+```bash
+conda run -n sictic-env python -m skills.harness /startup_profile SpaceX
+conda run -n sictic-env python -m skills.harness /dd_checks SpaceX
+conda run -n sictic-env python -m skills.harness /dataset_chat SpaceX "What are the main risks?"
+```
+
+Start the interactive harness with `--no-capture-output` so Conda keeps stdin
+open:
+
+```bash
+conda run -n sictic-env --no-capture-output python -m skills.harness
+```
+
+Administrative skills with their own command-line options are invoked directly:
+
+```bash
+conda run -n sictic-env python -m skills.bulk_refresh --dataset spacex --skill startup_profile
+conda run -n sictic-env python -m skills.dealum_import "Example Startup"
+conda run -n sictic-env python -m skills.dataset_maintenance diagnose
+```
+
+Consult each skill's `SKILL.md` for its current arguments and examples.
+
+## Google Drive synchronization
+
+All skills read and write the local filesystem below `LOCAL_STORAGE_PATH`.
+Google Drive access is isolated in the `gdrive_sync` utility under
+`gdrive-sync/`; normal application storage never accesses Drive directly.
+
+Required `.env` values:
+
+- `CLOUD_PROVIDER=google`
+- `LOCAL_STORAGE_PATH`: the local application storage root.
+- `CLOUD_STORAGE_PATH`: a Drive folder ID, `root`, or folder path/name.
+- `GDRIVE_CREDENTIALS`: OAuth Desktop-App credentials JSON.
+- `GDRIVE_TOKEN`: cached OAuth token JSON.
+
+Ask your coding agent to guide you through creating a Google OAuth Desktop-App
+client and authenticating it.
+
+Common commands:
+
+```bash
+python -m gdrive_sync pull
+python -m gdrive_sync sync --conflict-policy cloud-wins
+python -m gdrive_sync sync --conflict-policy local-wins
+```
+
+- `pull` makes local storage match Drive and establishes the initial baseline.
+- `cloud-wins` downloads cloud additions and updates without deleting files.
+- `local-wins` synchronizes both ways and keeps the local version on conflicts.
+- `--dry-run` previews changes; `--json` produces machine-readable output.
+
+The initial pull can take hours for a large Drive. Later synchronizations use a
+stored baseline and the Google Drive Changes API. Google Drive shortcuts are not
+supported inside the synchronized root.
+
+The synchronization baseline lives below
+`<REPO_PATH>/gdrive_sync_state/<pairing-id>/`. It is durable state and must
+not be deleted during cache cleanup.
+
+## Dataset maintenance
+
+```bash
+python -m skills.dataset_maintenance diagnose
+python -m skills.dataset_maintenance prune
+python -m skills.dataset_maintenance prune --apply
+python -m skills.dataset_maintenance migrate-startup-dossiers
+```
+
+Pruning is a dry run unless `--apply` is supplied.
+
+## Tests
+
+```bash
+conda run -n sictic-env python -m pytest -q
+```
+
+The default suite uses isolated local storage and mocked external services.
+Opt-in live tests require their external services and datasets:
+
+```bash
+SICTIC_RUN_LIVE_SMOKE=1 conda run -n sictic-env python -m pytest -q -m live
+```

--- a/install.sh
+++ b/install.sh
@@ -16,15 +16,17 @@
 #      If yes, updates it with --prune (removes deps no longer listed).
 #   2. Registers the repository root in the environment's site-packages using
 #      a generated .pth file, without invoking project dependency resolution.
-#   3. Copies every skill directory into <target>/<name>/. Existing installed
-#      skill directories are preserved under <target>/.skill-copy-backups/.
+#   3. Optionally copies every skill directory into <target>/<name>/. Existing
+#      installed skill directories are preserved under
+#      <target>/.skill-copy-backups/. Leave the target blank to work directly
+#      from the repository without installing agent-discoverable skill copies.
 #
 # Usage:
 #   ./install.sh                                      # interactive install
 #   ./install.sh --target /path/to/openclaw/skills    # optional target override
 #   ./install.sh --rebuild-env                        # force a fresh conda env
 #   ./install.sh --skip-env                           # skip steps 1+2
-#   ./install.sh --non-interactive --target ...       # do not prompt for .env values
+#   ./install.sh --non-interactive [--target ...]     # do not prompt for .env values
 
 set -eu
 
@@ -81,31 +83,27 @@ if [ -z "$TARGET" ]; then
         if [ -z "$target_default" ]; then
             target_default=$(env_file_get WORKSPACE_PATH "$REPO_ROOT/.env" || true)
         fi
-        while [ -z "$TARGET" ]; do
-            if [ -n "$target_default" ]; then
-                printf 'Installed skills path [%s]: ' "$target_default"
-            else
-                printf 'Installed skills path: '
-            fi
-            IFS= read -r target_answer || target_answer=""
-            if [ -z "$target_answer" ]; then
-                target_answer="$target_default"
-            fi
-            TARGET="$target_answer"
-            if [ -z "$TARGET" ]; then
-                echo "  INSTALLED_SKILLS_PATH is required."
-            fi
-        done
-    else
-        echo "install.sh: --target is required with --non-interactive." >&2
-        usage
-        exit 2
+        if [ -n "$target_default" ]; then
+            printf 'Installed skills path [%s] (type "none" for repository-only): ' "$target_default"
+        else
+            printf 'Installed skills path [none]: '
+        fi
+        IFS= read -r target_answer || target_answer=""
+        if [ -z "$target_answer" ]; then
+            target_answer="$target_default"
+        fi
+        case "$(printf '%s' "$target_answer" | tr '[:upper:]' '[:lower:]')" in
+            none) TARGET="" ;;
+            *) TARGET="$target_answer" ;;
+        esac
     fi
 fi
 
 # Ensure TARGET resolves to an absolute path for user-facing metadata.
-mkdir -p "$TARGET"
-TARGET="$(cd "$TARGET" && pwd)"
+if [ -n "$TARGET" ]; then
+    mkdir -p "$TARGET"
+    TARGET="$(cd "$TARGET" && pwd)"
+fi
 
 if [ ! -d "$REPO_ROOT/skills" ]; then
     echo "install.sh: $REPO_ROOT/skills not found." >&2
@@ -200,7 +198,11 @@ backup_existing_skill() {
 
 echo "Installing SICTIC-AI (conda variant)"
 echo "  source:   $REPO_ROOT"
-echo "  target:   $TARGET"
+if [ -n "$TARGET" ]; then
+    echo "  target:   $TARGET"
+else
+    echo "  target:   none (repository-only)"
+fi
 echo "  env name: $ENV_NAME"
 echo "  env file: $ENV_FILE"
 echo "  skills:   copy"
@@ -289,29 +291,34 @@ fi
 # ---------------------------------------------------------------------------
 # Step 3: install skills
 # ---------------------------------------------------------------------------
-echo "[3/3] Copying skills into $TARGET ..."
+if [ -n "$TARGET" ]; then
+    echo "[3/3] Copying skills into $TARGET ..."
+else
+    echo "[3/3] Skill copies: skipped (repository-only mode)"
+fi
 
 INSTALLED_LIST=""
 installed_count=0
 
-for src in "$REPO_ROOT/skills"/*/; do
-    src="${src%/}"
-    name=$(basename "$src")
-    [ -f "$src/SKILL.md" ] || continue
+if [ -n "$TARGET" ]; then
+    for src in "$REPO_ROOT/skills"/*/; do
+        src="${src%/}"
+        name=$(basename "$src")
+        [ -f "$src/SKILL.md" ] || continue
 
-    dst="$TARGET/$name"
+        dst="$TARGET/$name"
 
-    if [ -e "$dst" ] || [ -L "$dst" ]; then
-        backup_existing_skill "$dst"
-    fi
-    copy_skill_dir "$src" "$dst"
+        if [ -e "$dst" ] || [ -L "$dst" ]; then
+            backup_existing_skill "$dst"
+        fi
+        copy_skill_dir "$src" "$dst"
 
-    INSTALLED_LIST="$INSTALLED_LIST $name "
-    installed_count=$((installed_count + 1))
-    echo "       + $name"
-done
+        INSTALLED_LIST="$INSTALLED_LIST $name "
+        installed_count=$((installed_count + 1))
+        echo "       + $name"
+    done
 
-cat > "$TARGET/_SICTIC_AI.md" <<EOF
+    cat > "$TARGET/_SICTIC_AI.md" <<EOF
 # SICTIC-AI skills
 
 These skill directories are installed from \`$REPO_ROOT/skills/\` by:
@@ -331,7 +338,8 @@ from \`environment.yml\`.
 Each SKILL.md "Usage" section contains a harness slash command.
 EOF
 
-echo "       Installed $installed_count skill(s)."
+    echo "       Installed $installed_count skill(s)."
+fi
 
 # ---------------------------------------------------------------------------
 # Step 4: interactive .env setup
@@ -487,21 +495,31 @@ if [ "$INTERACTIVE" -eq 1 ]; then
     echo
 
     ask_env "REPO_PATH" "Repository path" "$REPO_ROOT" 1 0
-    ask_env "INSTALLED_SKILLS_PATH" "Installed skills path" "$TARGET" 1 0
-    ask_env "LOCAL_STORAGE_PATH" "Local application storage path" "$REPO_ROOT/.storage" 1 0
+    env_set "INSTALLED_SKILLS_PATH" "$TARGET"
+    ask_env "LOCAL_STORAGE_PATH" "Local application storage path" "$REPO_ROOT/local_storage" 1 0
     ask_env "LOCAL_DATA_PATH" "Local runtime cache path" "$REPO_ROOT" 1 0
-    ask_env "CLOUD_PROVIDER" "Cloud provider (blank or google)" "" 0 0
-    cloud_provider=$(env_get CLOUD_PROVIDER || true)
-    case "$(printf '%s' "$cloud_provider" | tr '[:upper:]' '[:lower:]')" in
-        "") ;;
-        google)
-            ask_env "CLOUD_STORAGE_PATH" "Google Drive folder ID, root, or folder path/name" "" 1 0
-            ;;
+    cloud_provider_current=$(env_get CLOUD_PROVIDER || true)
+    if [ -n "$cloud_provider_current" ]; then
+        printf 'Cloud provider [current: %s] (google or none): ' "$cloud_provider_current"
+    else
+        printf 'Cloud provider [none] (google or none): '
+    fi
+    IFS= read -r cloud_provider_answer || cloud_provider_answer=""
+    if [ -z "$cloud_provider_answer" ]; then
+        cloud_provider_answer="$cloud_provider_current"
+    fi
+    case "$(printf '%s' "$cloud_provider_answer" | tr '[:upper:]' '[:lower:]')" in
+        ""|none) env_set "CLOUD_PROVIDER" "" ;;
+        google) env_set "CLOUD_PROVIDER" "google" ;;
         *)
-            echo "  CLOUD_PROVIDER must be blank or google." >&2
+            echo "  CLOUD_PROVIDER must be google or none." >&2
             exit 1
             ;;
     esac
+    cloud_provider=$(env_get CLOUD_PROVIDER || true)
+    if [ "$cloud_provider" = "google" ]; then
+        ask_env "CLOUD_STORAGE_PATH" "Google Drive folder ID, root, or folder path/name" "" 1 0
+    fi
 
     ask_env "QDRANT_HOST" "Qdrant host" "$(env_get QDRANT_HOST || true)" 1 0
     ask_env "OLLAMA_HOST" "Ollama host (fallback for local Ollama models)" "$(env_get OLLAMA_HOST || true)" 1 0
@@ -533,8 +551,10 @@ if [ "$INTERACTIVE" -eq 1 ]; then
     ask_env "OLLAMA_MAX_LOADED_MODELS" "Ollama max loaded models" "$(env_get OLLAMA_MAX_LOADED_MODELS || true)" 1 0
     ask_env "OLLAMA_KV_CACHE_TYPE" "Ollama KV cache type" "$(env_get OLLAMA_KV_CACHE_TYPE || true)" 0 0
     ask_env "OLLAMA_FLASH_ATTENTION" "Ollama flash attention flag" "$(env_get OLLAMA_FLASH_ATTENTION || true)" 0 0
-    ask_env "GDRIVE_CREDENTIALS" "Google credentials path (blank to use default)" "$(env_get GDRIVE_CREDENTIALS || true)" 0 1
-    ask_env "GDRIVE_TOKEN" "Google token path (blank to use default)" "$(env_get GDRIVE_TOKEN || true)" 0 1
+    if [ "$cloud_provider" = "google" ]; then
+        ask_env "GDRIVE_CREDENTIALS" "Google credentials path (blank to use default)" "$(env_get GDRIVE_CREDENTIALS || true)" 0 1
+        ask_env "GDRIVE_TOKEN" "Google token path (blank to use default)" "$(env_get GDRIVE_TOKEN || true)" 0 1
+    fi
     ask_env "GEMINI_API_KEY" "Gemini API key (blank if unused)" "$(env_get GEMINI_API_KEY || true)" 0 1
     ask_env "APIFY_KEY" "Apify API key (blank if unused)" "$(env_get APIFY_KEY || true)" 0 1
     ask_env "DEALUM_API_KEY" "Dealum API key (blank if unused)" "$(env_get DEALUM_API_KEY || true)" 0 1
@@ -543,8 +563,8 @@ if [ "$INTERACTIVE" -eq 1 ]; then
 else
     echo "[4/4] .env prompts skipped (--non-interactive)."
     if [ -z "$(env_get REPO_PATH || true)" ]; then env_set "REPO_PATH" "$REPO_ROOT"; fi
-    if [ -z "$(env_get INSTALLED_SKILLS_PATH || true)" ]; then env_set "INSTALLED_SKILLS_PATH" "$TARGET"; fi
-    if [ -z "$(env_get LOCAL_STORAGE_PATH || true)" ]; then env_set "LOCAL_STORAGE_PATH" "$REPO_ROOT/.storage"; fi
+    env_set "INSTALLED_SKILLS_PATH" "$TARGET"
+    if [ -z "$(env_get LOCAL_STORAGE_PATH || true)" ]; then env_set "LOCAL_STORAGE_PATH" "$REPO_ROOT/local_storage"; fi
     if [ -z "$(env_get LOCAL_DATA_PATH || true)" ]; then env_set "LOCAL_DATA_PATH" "$REPO_ROOT"; fi
 fi
 

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -96,8 +96,147 @@ def test_install_script_copies_skills_and_sets_env(tmp_path):
     assert f"REPO_PATH={source}" in env_file
     assert f"INSTALLED_SKILLS_PATH={target}" in env_file
     assert "WORKSPACE_PATH=" not in env_file
-    assert f"LOCAL_STORAGE_PATH={source / '.storage'}" in env_file
+    assert f"LOCAL_STORAGE_PATH={source / 'local_storage'}" in env_file
     assert f"LOCAL_DATA_PATH={source}" in env_file
     assert "STORAGE_PROVIDER=" not in env_file
     assert "DEFAULT_LLM=" not in env_file
     assert "OLLAMA_NUM_CTX=" not in env_file
+
+
+def test_install_script_supports_repository_only_mode(tmp_path):
+    repo_root = Path(__file__).resolve().parents[1]
+    source = tmp_path / "source"
+    fake_site_packages = tmp_path / "site-packages"
+    fake_site_packages.mkdir()
+
+    skill_dir = source / "skills" / "example_skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("---\nname: example_skill\n---\n", encoding="utf-8")
+    (source / "environment.yml").write_text(
+        "name: sictic-test\n"
+        "dependencies:\n"
+        "  - python=3.12\n",
+        encoding="utf-8",
+    )
+    (source / ".env-template").write_text(
+        "REPO_PATH=\n"
+        "INSTALLED_SKILLS_PATH=\n"
+        "LOCAL_STORAGE_PATH=\n"
+        "LOCAL_DATA_PATH=\n"
+        "CLOUD_PROVIDER=\n"
+        "CLOUD_STORAGE_PATH=\n",
+        encoding="utf-8",
+    )
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_python = fake_bin / "python-fake"
+    fake_python.write_text(
+        "#!/bin/sh\n"
+        "if [ \"$1\" = \"-m\" ] && [ \"$2\" = \"pip\" ]; then exit 0; fi\n"
+        "if [ \"$1\" = \"-c\" ]; then printf '%s\\n' \"$FAKE_SITE_PACKAGES\"; exit 0; fi\n"
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    fake_python.chmod(0o755)
+    fake_conda = fake_bin / "conda"
+    fake_conda.write_text(
+        "#!/bin/sh\n"
+        "if [ \"$1\" = \"run\" ]; then printf '%s\\n' \"$FAKE_PYTHON\"; exit 0; fi\n"
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    fake_conda.chmod(0o755)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+    env["FAKE_PYTHON"] = str(fake_python)
+    env["FAKE_SITE_PACKAGES"] = str(fake_site_packages)
+
+    result = subprocess.run(
+        [
+            str(repo_root / "install.sh"),
+            "--source",
+            str(source),
+            "--skip-env",
+            "--non-interactive",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "repository-only" in result.stdout
+    env_file = (source / ".env").read_text(encoding="utf-8")
+    assert "INSTALLED_SKILLS_PATH=\n" in env_file
+    assert f"LOCAL_STORAGE_PATH={source / 'local_storage'}" in env_file
+    assert f"LOCAL_DATA_PATH={source}" in env_file
+
+
+def test_fresh_interactive_install_does_not_require_google(tmp_path):
+    repo_root = Path(__file__).resolve().parents[1]
+    source = tmp_path / "source"
+    fake_site_packages = tmp_path / "site-packages"
+    fake_site_packages.mkdir()
+
+    skill_dir = source / "skills" / "example_skill"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text("---\nname: example_skill\n---\n", encoding="utf-8")
+    (source / "environment.yml").write_text(
+        "name: sictic-test\n"
+        "dependencies:\n"
+        "  - python=3.12\n",
+        encoding="utf-8",
+    )
+    (source / ".env-template").write_text(
+        (repo_root / ".env-template").read_text(encoding="utf-8"),
+        encoding="utf-8",
+    )
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    fake_python = fake_bin / "python-fake"
+    fake_python.write_text(
+        "#!/bin/sh\n"
+        "if [ \"$1\" = \"-m\" ] && [ \"$2\" = \"pip\" ]; then exit 0; fi\n"
+        "if [ \"$1\" = \"-c\" ]; then printf '%s\\n' \"$FAKE_SITE_PACKAGES\"; exit 0; fi\n"
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    fake_python.chmod(0o755)
+    fake_conda = fake_bin / "conda"
+    fake_conda.write_text(
+        "#!/bin/sh\n"
+        "if [ \"$1\" = \"run\" ]; then printf '%s\\n' \"$FAKE_PYTHON\"; exit 0; fi\n"
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    fake_conda.chmod(0o755)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+    env["FAKE_PYTHON"] = str(fake_python)
+    env["FAKE_SITE_PACKAGES"] = str(fake_site_packages)
+
+    result = subprocess.run(
+        [
+            str(repo_root / "install.sh"),
+            "--source",
+            str(source),
+            "--skip-env",
+        ],
+        input="\n" * 40,
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Google Drive folder ID" not in result.stdout
+    assert "Google credentials path" not in result.stdout
+    env_file = (source / ".env").read_text(encoding="utf-8")
+    assert "CLOUD_PROVIDER=\n" in env_file
+    assert f"LOCAL_STORAGE_PATH={source / 'local_storage'}" in env_file


### PR DESCRIPTION
## What changed

- Make Google Drive opt-in and skip Google-specific prompts when it is disabled.
- Support installs without copying skills into an agent skills directory.
- Use `<REPO_PATH>/local_storage` as the suggested local storage location.
- Simplify the README around an AI-agent-first setup flow.
- Document manual installation, model switching, storage paths, user-facing skills, and detailed operations.
- Add installer regression tests for targeted, repository-only, and non-Google installations.

## Why

Dominik and I ran the install script and encountered setup bugs, particularly when Google Drive was not configured. The README had also become long and mixed basic setup with advanced operations, making first-time installation harder than necessary.

## Impact

New users get a local-only setup by default, can work directly from the repository without copying skills, and can hand the documented setup prompt to a coding agent. Existing Google Drive users can still opt in with `CLOUD_PROVIDER=google`.

## Root cause

`.env-template` preselected Google as the cloud provider, and the interactive prompt could not clear that inherited value. The installer also required a skill-copy target even though direct repository execution works without one.

## Validation

- `git diff --check`
- Full test suite: **449 passed, 5 skipped**
