### PR TITLE
Cloud Agent secrets, Docling OCR, and VLM setup

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -42,7 +42,10 @@ CLOUD_PROVIDER=google
 CLOUD_STORAGE_PATH=
 
 # (Optional) Google Drive Credentials
-# Defaults to ~/.openclaw/gdrive-ops-credentials.json if empty
+# Prefer JSON secrets in Cloud Agents (materialized to files on install/start):
+#   GDRIVE_CREDENTIALS_JSON  Desktop OAuth client secrets JSON
+#   GDRIVE_TOKEN_JSON        Authorized-user token JSON
+# Path vars below point at the written files (defaults under ~/.openclaw/):
 GDRIVE_CREDENTIALS=
 GDRIVE_TOKEN=
 

--- a/environment.yml
+++ b/environment.yml
@@ -38,11 +38,13 @@ dependencies:
 
   - pip:
       # Not on conda-forge. Docling uses ocrmac on macOS and RapidOCR on Linux.
+      # RapidOCR needs onnxruntime; it is not pulled in by the base docling wheel.
       - apify-client
       - langchain-text-splitters
       - ollama
       - 'docling[ocrmac]==2.96.1; platform_system == "Darwin"'
       - 'docling==2.96.1; platform_system != "Darwin"'
+      - 'onnxruntime; platform_system != "Darwin"'
       - torch==2.10.0
       - torchvision==0.25.0
       - 'ocrmac==1.0.1; platform_system == "Darwin"'

--- a/lib/adapters/docling/converter.py
+++ b/lib/adapters/docling/converter.py
@@ -59,7 +59,7 @@ def build_converter(*, force_full_page_ocr: bool = False):
         picture_description_options=PictureDescriptionApiOptions(
             url=chat_completions_url(vlm_base_url),
             headers=headers,
-            params={"model": vlm_model, "max_tokens": 200},
+            params=picture_description_params(vlm_model),
             prompt="Describe this image in a few sentences.",
             timeout=600,
         ),
@@ -137,6 +137,15 @@ def convert_document_force_ocr(filepath: str) -> str:
     with _convert_lock:
         result = converter.convert(filepath)
     return export_document_markdown(result.document)
+
+
+def picture_description_params(model: str) -> dict[str, object]:
+    """Chat-completions extras for Docling picture descriptions.
+
+    Newer OpenAI models (including gpt-5.6-luna) reject `max_tokens` and
+    require `max_completion_tokens`.
+    """
+    return {"model": model, "max_completion_tokens": 200}
 
 
 def chat_completions_url(base_url: str) -> str:

--- a/scripts/cloud-agent-dotenv-secrets.sh
+++ b/scripts/cloud-agent-dotenv-secrets.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Copy Cloud Agent secrets from the process environment into .env.
+# lib/env.py loads .env with override=True, so empty template keys wipe
+# live secrets unless the injected values are written first.
+#
+# Source this file; call seed_dotenv_secrets <env_file>.
+# Requires env_set KEY VALUE PATH to be defined by the caller.
+#
+# shellcheck shell=bash
+
+seed_dotenv_secrets() {
+  local env_path="${1:-}"
+  local key value
+
+  if [ -z "$env_path" ] || [ ! -f "$env_path" ]; then
+    return 0
+  fi
+  if ! declare -F env_set >/dev/null 2>&1; then
+    return 0
+  fi
+
+  for key in DEALUM_API_KEY DEALUM_DEALROOM_ID; do
+    value="${!key:-}"
+    if [ -n "$value" ]; then
+      env_set "$key" "$value" "$env_path"
+    fi
+  done
+}

--- a/scripts/cloud-agent-gdrive-secrets.sh
+++ b/scripts/cloud-agent-gdrive-secrets.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Materialize Cloud Agent GDrive JSON secrets into credential files.
+# Runtime (gdrive_sync / GoogleDriveStorage) expects file paths in
+# GDRIVE_CREDENTIALS and GDRIVE_TOKEN. Secrets UI can hold JSON in
+# GDRIVE_CREDENTIALS_JSON / GDRIVE_TOKEN_JSON (preferred) or, for
+# backwards compatibility, JSON blobs in GDRIVE_CREDENTIALS / GDRIVE_TOKEN.
+#
+# Source this file; call materialize_gdrive_secrets [env_file].
+# When env_file is given, path vars are written there. Process env is
+# always updated so the current boot sees the paths.
+#
+# shellcheck shell=bash
+
+# Write JSON content to dest (mode 0600). If content is already an existing
+# file path, print that path. Prints the path used on stdout.
+# Returns 1 when content is empty or neither JSON nor an existing file.
+materialize_json_secret() {
+  local content="$1"
+  local dest="$2"
+  local trimmed
+
+  if [ -z "${content}" ]; then
+    return 1
+  fi
+
+  # Trim leading whitespace for the JSON-vs-path check only.
+  trimmed="${content#"${content%%[![:space:]]*}"}"
+  case "$trimmed" in
+    \{*)
+      mkdir -p "$(dirname "$dest")"
+      CONTENT="$content" DEST="$dest" python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+raw = os.environ["CONTENT"]
+path = Path(os.environ["DEST"])
+try:
+    json.loads(raw)
+except json.JSONDecodeError as exc:
+    raise SystemExit(f"invalid JSON for {path}: {exc}") from exc
+path.write_text(raw, encoding="utf-8")
+path.chmod(0o600)
+print(path)
+PY
+      ;;
+    *)
+      if [ -f "$content" ]; then
+        printf '%s\n' "$content"
+        return 0
+      fi
+      if [ -f "${content/#\~/$HOME}" ]; then
+        printf '%s\n' "${content/#\~/$HOME}"
+        return 0
+      fi
+      return 1
+      ;;
+  esac
+}
+
+# Prefer *_JSON secrets; fall back to GDRIVE_* (path or legacy JSON blob).
+materialize_gdrive_secrets() {
+  local env_path="${1:-}"
+  local creds_dest="${GDRIVE_CREDENTIALS_FILE:-$HOME/.openclaw/gdrive-ops-credentials.json}"
+  local token_dest="${GDRIVE_TOKEN_FILE:-$HOME/.openclaw/gdrive-ops-token.json}"
+  local materialized
+  local wrote=0
+
+  if materialized=$(materialize_json_secret \
+      "${GDRIVE_CREDENTIALS_JSON:-${GDRIVE_CREDENTIALS:-}}" "$creds_dest"); then
+    export GDRIVE_CREDENTIALS="$materialized"
+    if [ -n "$env_path" ] && [ -f "$env_path" ] && declare -F env_set >/dev/null 2>&1; then
+      env_set "GDRIVE_CREDENTIALS" "$materialized" "$env_path"
+    fi
+    wrote=1
+  fi
+
+  if materialized=$(materialize_json_secret \
+      "${GDRIVE_TOKEN_JSON:-${GDRIVE_TOKEN:-}}" "$token_dest"); then
+    export GDRIVE_TOKEN="$materialized"
+    if [ -n "$env_path" ] && [ -f "$env_path" ] && declare -F env_set >/dev/null 2>&1; then
+      env_set "GDRIVE_TOKEN" "$materialized" "$env_path"
+    fi
+    wrote=1
+  fi
+
+  if [ "$wrote" -eq 1 ]; then
+    echo "cloud-agent-gdrive-secrets: materialized GDrive credential files" >&2
+  fi
+}

--- a/scripts/cloud-agent-install.sh
+++ b/scripts/cloud-agent-install.sh
@@ -86,6 +86,11 @@ seed_cloud_env() {
     env_set "EMBEDDING_API_KEY" "$OPENROUTER_API_KEY" "$env_path"
   fi
 
+  # Dealum: copy injected secrets so empty .env-template keys cannot wipe them.
+  # shellcheck disable=SC1091
+  source "$REPO_ROOT/scripts/cloud-agent-dotenv-secrets.sh"
+  seed_dotenv_secrets "$env_path"
+
   # GDrive: secrets UI holds JSON; runtime expects paths. Prefer *_JSON.
   # shellcheck disable=SC1091
   source "$REPO_ROOT/scripts/cloud-agent-gdrive-secrets.sh"

--- a/scripts/cloud-agent-install.sh
+++ b/scripts/cloud-agent-install.sh
@@ -85,6 +85,11 @@ seed_cloud_env() {
   elif [ -n "${OPENROUTER_API_KEY:-}" ]; then
     env_set "EMBEDDING_API_KEY" "$OPENROUTER_API_KEY" "$env_path"
   fi
+
+  # GDrive: secrets UI holds JSON; runtime expects paths. Prefer *_JSON.
+  # shellcheck disable=SC1091
+  source "$REPO_ROOT/scripts/cloud-agent-gdrive-secrets.sh"
+  materialize_gdrive_secrets "$env_path"
 }
 
 ensure_conda

--- a/scripts/cloud-agent-start.sh
+++ b/scripts/cloud-agent-start.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Per-boot Cloud Agent start: materialize GDrive secrets, bring up Qdrant.
+# Per-boot Cloud Agent start: materialize GDrive/Dealum secrets, bring up Qdrant.
 # Docling is an in-process library. Skips Ollama; embeddings/LLM use API keys.
 set -euo pipefail
 
@@ -12,7 +12,7 @@ if ! command -v conda >/dev/null 2>&1 && [ -x "$HOME/miniforge3/bin/conda" ]; th
 fi
 
 # Builds skip install on later boots; secrets are injected per pod, so refresh
-# GDrive credential files and .env path pointers on every start.
+# GDrive credential files, Dealum keys, and .env path pointers on every start.
 env_set() {
   local key="$1"
   local value="$2"
@@ -35,8 +35,11 @@ env_set() {
 
 # shellcheck disable=SC1091
 source "$REPO_ROOT/scripts/cloud-agent-gdrive-secrets.sh"
+# shellcheck disable=SC1091
+source "$REPO_ROOT/scripts/cloud-agent-dotenv-secrets.sh"
 if [ -f "$REPO_ROOT/.env" ]; then
   materialize_gdrive_secrets "$REPO_ROOT/.env"
+  seed_dotenv_secrets "$REPO_ROOT/.env"
 else
   materialize_gdrive_secrets
 fi

--- a/scripts/cloud-agent-start.sh
+++ b/scripts/cloud-agent-start.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# Per-boot Cloud Agent start: bring up Qdrant (Docling is an in-process library).
-# Skips Ollama; embeddings/LLM use OpenRouter/OpenAI via API keys.
+# Per-boot Cloud Agent start: materialize GDrive secrets, bring up Qdrant.
+# Docling is an in-process library. Skips Ollama; embeddings/LLM use API keys.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -9,6 +9,36 @@ cd "$REPO_ROOT"
 if ! command -v conda >/dev/null 2>&1 && [ -x "$HOME/miniforge3/bin/conda" ]; then
   # shellcheck disable=SC1091
   eval "$("$HOME/miniforge3/bin/conda" shell.bash hook)"
+fi
+
+# Builds skip install on later boots; secrets are injected per pod, so refresh
+# GDrive credential files and .env path pointers on every start.
+env_set() {
+  local key="$1"
+  local value="$2"
+  local path="$3"
+  local tmp escaped
+  tmp="${path}.tmp.$$"
+  escaped=$(printf '%s' "$value" | sed 's/[\/&]/\\&/g')
+  if [ -f "$path" ] && grep -q "^[[:space:]]*$key[[:space:]]*=" "$path"; then
+    sed "s/^\\([[:space:]]*$key[[:space:]]*=\\).*/\\1$escaped/" "$path" > "$tmp"
+  else
+    if [ -f "$path" ]; then
+      cp "$path" "$tmp"
+    else
+      : > "$tmp"
+    fi
+    printf '%s=%s\n' "$key" "$value" >> "$tmp"
+  fi
+  mv "$tmp" "$path"
+}
+
+# shellcheck disable=SC1091
+source "$REPO_ROOT/scripts/cloud-agent-gdrive-secrets.sh"
+if [ -f "$REPO_ROOT/.env" ]; then
+  materialize_gdrive_secrets "$REPO_ROOT/.env"
+else
+  materialize_gdrive_secrets
 fi
 
 ./launch.sh start qdrant

--- a/tests/adapters/test_docling_adapter.py
+++ b/tests/adapters/test_docling_adapter.py
@@ -318,3 +318,13 @@ def test_chat_completions_model_strips_ollama_prefix_only_for_ollama_host():
     assert _chat_completions_model("http://localhost:8080/v1", "ollama/qwen3-vl:8b") == (
         "ollama/qwen3-vl:8b"
     )
+
+
+def test_picture_description_params_use_max_completion_tokens():
+    from lib.adapters.docling.converter import picture_description_params
+
+    assert picture_description_params("gpt-5.6-luna") == {
+        "model": "gpt-5.6-luna",
+        "max_completion_tokens": 200,
+    }
+    assert "max_tokens" not in picture_description_params("gpt-4o-mini")

--- a/tests/scripts/test_cloud_agent_dotenv_secrets.py
+++ b/tests/scripts/test_cloud_agent_dotenv_secrets.py
@@ -1,0 +1,71 @@
+import os
+import subprocess
+from pathlib import Path
+
+
+HELPER = Path(__file__).resolve().parents[2] / "scripts" / "cloud-agent-dotenv-secrets.sh"
+
+
+def _run_seed(tmp_path: Path, env_text: str, extra_env: dict[str, str]) -> str:
+    env_file = tmp_path / ".env"
+    env_file.write_text(env_text, encoding="utf-8")
+    script = tmp_path / "run.sh"
+    script.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        "env_set() {\n"
+        "  local key=\"$1\" value=\"$2\" path=\"$3\" tmp\n"
+        "  tmp=\"${path}.tmp.$$\"\n"
+        "  if grep -q \"^[[:space:]]*$key[[:space:]]*=\" \"$path\"; then\n"
+        "    sed \"s/^\\\\([[:space:]]*$key[[:space:]]*=\\\\).*/\\\\1$value/\" \"$path\" > \"$tmp\"\n"
+        "  else\n"
+        "    cp \"$path\" \"$tmp\"\n"
+        "    printf '%s=%s\\n' \"$key\" \"$value\" >> \"$tmp\"\n"
+        "  fi\n"
+        "  mv \"$tmp\" \"$path\"\n"
+        "}\n"
+        f"source '{HELPER}'\n"
+        f"seed_dotenv_secrets '{env_file}'\n",
+        encoding="utf-8",
+    )
+    script.chmod(0o755)
+    env = os.environ.copy()
+    env.pop("DEALUM_API_KEY", None)
+    env.pop("DEALUM_DEALROOM_ID", None)
+    env.update(extra_env)
+    result = subprocess.run(
+        ["bash", str(script)],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert result.returncode == 0, result.stderr
+    return env_file.read_text(encoding="utf-8")
+
+
+def test_seed_dotenv_secrets_writes_dealum_keys(tmp_path):
+    text = _run_seed(
+        tmp_path,
+        "DEALUM_API_KEY=\nDEALUM_DEALROOM_ID=\n",
+        {"DEALUM_API_KEY": "dealum-test-key", "DEALUM_DEALROOM_ID": "12345"},
+    )
+    assert "DEALUM_API_KEY=dealum-test-key" in text
+    assert "DEALUM_DEALROOM_ID=12345" in text
+
+
+def test_seed_dotenv_secrets_leaves_empty_keys_when_unset(tmp_path):
+    text = _run_seed(
+        tmp_path,
+        "DEALUM_API_KEY=\nDEALUM_DEALROOM_ID=\n",
+        {},
+    )
+    assert "DEALUM_API_KEY=\n" in text
+    assert "DEALUM_DEALROOM_ID=\n" in text
+
+
+def test_environment_yml_pins_onnxruntime_for_linux():
+    yaml_text = (
+        Path(__file__).resolve().parents[2] / "environment.yml"
+    ).read_text(encoding="utf-8")
+    assert "onnxruntime; platform_system != \"Darwin\"" in yaml_text


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Cloud Agent install/start now keeps GDrive and Dealum secrets usable after snapshot, and Linux Docling can convert PDFs and describe images with `gpt-5.6-luna`.

## Changes
- Write GDrive OAuth JSON secrets to `~/.openclaw/gdrive-ops-*.json` (mode `0600`) and point `GDRIVE_CREDENTIALS` / `GDRIVE_TOKEN` at those files. Prefer `*_JSON`; fall back to JSON blobs already in the path vars.
- Copy `DEALUM_API_KEY` and `DEALUM_DEALROOM_ID` from the process environment into `.env` on install and start. `lib/env.py` loads `.env` with `override=True`, so empty template keys were wiping injected secrets.
- Pin `onnxruntime` on Linux in `environment.yml`. RapidOCR does not pull it in with the base Docling wheel.
- Send `max_completion_tokens` instead of `max_tokens` for Docling picture descriptions. `gpt-5.6-luna` rejects `max_tokens`.

## How to verify
1. Set Cloud Agent secrets: `GDRIVE_CREDENTIALS_JSON`, `GDRIVE_TOKEN_JSON`, `DEALUM_API_KEY`, `DEALUM_DEALROOM_ID`, `VLM_MODEL=gpt-5.6-luna`.
2. Start a new agent from this branch (or a build of it).
3. Confirm `~/.openclaw/gdrive-ops-*.json` exist and `.env` has Dealum keys plus GDrive paths.
4. Convert a PDF with Docling and confirm picture-description calls no longer fail with `invalid model ID` or `max_tokens`.

## Test plan
- [x] GDrive helper: `*_JSON` write, path re-run, legacy JSON fallback, invalid JSON rejected
- [x] Dealum helper writes keys when set and leaves blanks when unset
- [x] Docling params use `max_completion_tokens`
- [x] `environment.yml` pins Linux `onnxruntime`
- [x] Fresh agent / environment build on this branch

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-132c5572-0cf6-4cb9-99f6-4e85b90535df?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-132c5572-0cf6-4cb9-99f6-4e85b90535df&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

