### PR TITLE
Compare insight hydration by content hash

### DIFF
--- a/lib/insights/hydration.py
+++ b/lib/insights/hydration.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import PurePosixPath
 
+from lib.datasets.manifest import content_hash
 from lib.datasets.paths import dataset_location_for_domain
 from lib.insights.file import InsightFile
 from lib.logger import get_logger
@@ -77,13 +78,11 @@ async def dataset_from_insight(
     unchanged = 0
     for relative_target, insight in desired.items():
         destination = f"{target_rel}/{relative_target}"
-        target_mtime = existing.pop(relative_target, None)
-        source_mtime = storage.mtime(insight.path)
-        copy_required = (
-            target_mtime is None
-            or source_mtime is None
-            or source_mtime > target_mtime
-        )
+        target_exists = existing.pop(relative_target, None) is not None
+        source_bytes = storage.read_bytes(insight.path)
+        copy_required = not target_exists or content_hash(
+            source_bytes
+        ) != content_hash(storage.read_bytes(destination))
         if not copy_required:
             unchanged += 1
             logger.debug("Skipped up-to-date file %s.", destination)
@@ -96,7 +95,7 @@ async def dataset_from_insight(
                 destination,
             )
         else:
-            storage.write_bytes(destination, storage.read_bytes(insight.path))
+            storage.write_bytes(destination, source_bytes)
         copied += 1
 
     removed = 0

--- a/tests/scripts/test_profile_sync_scripts.py
+++ b/tests/scripts/test_profile_sync_scripts.py
@@ -178,7 +178,7 @@ async def test_dataset_from_insight_without_sources_scans_all_datasets(mock_env,
 
 
 @pytest.mark.asyncio
-async def test_dataset_from_insight_copies_only_when_source_is_newer(
+async def test_dataset_from_insight_copies_only_when_content_differs(
     mock_env,
     monkeypatch,
 ):
@@ -205,14 +205,24 @@ async def test_dataset_from_insight_copies_only_when_source_is_newer(
     )
     assert storage.read_text(target) == "new source"
 
-    storage.write_text(target, "newer target")
-    storage.set_mtime(target, 300)
+    storage.set_mtime(target, 100)
+    storage.set_mtime(source, 300)
+    target_mtime = storage.mtime(target)
     await dataset_from_insight(
         "avientus-startup-profile",
         ["avientus"],
         "startup_profile",
     )
-    assert storage.read_text(target) == "newer target"
+    assert storage.mtime(target) == target_mtime
+
+    storage.write_text(target, "newer target")
+    storage.set_mtime(target, 400)
+    await dataset_from_insight(
+        "avientus-startup-profile",
+        ["avientus"],
+        "startup_profile",
+    )
+    assert storage.read_text(target) == "new source"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- compare generated insight source and destination contents using the existing SHA-256 helper
- avoid rewriting identical files when only timestamps differ
- copy changed content even when the destination timestamp is newer

## Tests
- 15 hydration/profile sync tests passed
- 11 downstream ranking and suggested-startup tests passed