### PR TITLE
Hybrid retrieval

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -15,6 +15,23 @@ EMBEDDING_MODEL="ollama/qwen3-embedding:8b"
 EMBEDDING_BASE_URL=http://localhost:11434
 EMBEDDING_API_KEY=
 
+# RETRIEVAL
+# Dense and BM25 results are fused in Qdrant. These tune what happens after.
+# RETRIEVAL_CANDIDATE_MULTIPLIER: how many candidates to retrieve per returned
+# chunk, giving reranking and diversification room to work.
+# RETRIEVAL_MAX_DOCUMENT_SHARE: largest share of the returned chunks that any
+# single document may occupy. Use 0 or 1 to disable the cap.
+RETRIEVAL_CANDIDATE_MULTIPLIER=4
+RETRIEVAL_MAX_DOCUMENT_SHARE=0.4
+
+# Optional cross-encoder reranking. Blank RERANK_MODEL disables it.
+# A local reranker keeps data on the machine, for example a self-hosted
+# Infinity server: RERANK_MODEL="infinity/BAAI/bge-reranker-v2-m3" with
+# RERANK_BASE_URL=http://localhost:7997
+RERANK_MODEL=
+RERANK_BASE_URL=
+RERANK_API_KEY=
+
 OLLAMA_CONTEXT_LENGTH=32768
 OLLAMA_CONTEXT_LENGTH_MAX=262144
 OLLAMA_NUM_PARALLEL=16

--- a/README.md
+++ b/README.md
@@ -151,6 +151,9 @@ configure these variables:
 |14| `EMBEDDING_BASE_URL` | Base URL for the embedding endpoint; blank uses the provider default | `http://localhost:11434` |
 |15| `EMBEDDING_API_KEY` | API key for the embedding endpoint when needed | blank for local Ollama |
 |16| `RANKED_LLMS` | If insights md files were created with several models, the preferred ranking for re-use. (CSV list) | see `.env-template` |
+|17| `RERANK_MODEL` | Optional cross-encoder that rescores retrieved chunks; blank disables reranking | `infinity/BAAI/bge-reranker-v2-m3` |
+|18| `RERANK_BASE_URL` | Base URL for the reranking endpoint | `http://localhost:7997` |
+|19| `RERANK_API_KEY` | API key for the reranking endpoint when needed | blank for a local reranker |
 
 *(Note: The other variables in `.env-template` are explained inline. You don't need to change them).*
 
@@ -424,6 +427,55 @@ python -m skills.dataset_maintenance diagnose
 python -m skills.dataset_maintenance prune
 python -m skills.dataset_maintenance prune --apply
 python -m skills.dataset_maintenance migrate-startup-dossiers
+python -m skills.dataset_maintenance rebuild-index --dataset avientus
 ```
 
 Pruning is dry-run by default.
+
+## Retrieval
+
+Search over a data room runs in three stages.
+
+**1. Hybrid retrieval.** Every question is matched twice against the same Qdrant
+collection: once as a dense embedding, and once as BM25 keyword terms. Qdrant
+fuses the two rankings with reciprocal rank fusion. The dense side handles
+paraphrases, and the BM25 side handles the exact strings that matter in a data
+room and that a small local embedding model tends to blur, such as
+`Inventionsabtretungserklärung`, `Art. 332 OR`, or a specific patent number.
+BM25 needs no extra model or service: Qdrant computes the inverse document
+frequency itself, so only term frequencies are stored alongside each chunk.
+
+**2. Optional reranking.** When `RERANK_MODEL` is set, a cross-encoder rescores
+the retrieved candidates by reading the question and the chunk together. This is
+off by default. A local reranker keeps confidential documents on the machine,
+for example a self-hosted [Infinity](https://github.com/michaelfeil/infinity)
+server:
+
+```bash
+RERANK_MODEL="infinity/BAAI/bge-reranker-v2-m3"
+RERANK_BASE_URL=http://localhost:7997
+```
+
+If the reranker is unreachable or fails, retrieval keeps the fusion order and
+logs a warning, so search never breaks because of it.
+
+**3. Diversification.** Retrieval runs wider than the requested chunk count
+(`RETRIEVAL_CANDIDATE_MULTIPLIER`) and then caps how much of the answer a single
+document may occupy (`RETRIEVAL_MAX_DOCUMENT_SHARE`). This stops one long
+document, such as a 200-page shareholder agreement, from filling the whole
+context and hiding the cap table. Chunks above the cap are demoted rather than
+dropped, so the requested number of chunks is still returned.
+
+### Upgrading an existing index
+
+Qdrant cannot add sparse vectors to a collection that was created without them,
+so datasets indexed before hybrid search keep working as dense-only search until
+their collection is rebuilt:
+
+```bash
+python -m skills.dataset_maintenance rebuild-index --dataset avientus
+```
+
+This drops the Qdrant collection and re-embeds the dataset. Parsed Markdown is
+kept, so documents are never sent through Docling again. Rebuilding is the
+expensive step for a large data room; run it once per dataset when convenient.

--- a/lib/adapters/qdrant.py
+++ b/lib/adapters/qdrant.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Optional
 
+from lib.datasets.sparse import SparseVectorData
 from lib.env import get_env_var
 from lib.logger import get_logger
 from lib.model_config import embedding_model
@@ -16,13 +17,24 @@ with suppress_native_stderr():
         Distance,
         FieldCondition,
         Filter,
+        Fusion,
+        FusionQuery,
         MatchValue,
+        Modifier,
         PointIdsList,
         PointStruct,
+        Prefetch,
+        SparseVector,
+        SparseVectorParams,
         VectorParams,
     )
 
 logger = get_logger(__name__)
+
+# Dense vectors stay on Qdrant's default unnamed vector so that collections
+# created before hybrid search remain queryable without migration.
+DENSE_VECTOR_NAME = ""
+SPARSE_VECTOR_NAME = "bm25"
 
 
 class QdrantAdmin:
@@ -64,6 +76,7 @@ class QdrantAdapter:
     ):
         self.client = QdrantClient(url=get_env_var("QDRANT_HOST"))
         self.collection_name = self.collection_for(collection_name)
+        self._sparse_enabled: bool | None = None
         if vector_size is not None:
             self.ensure_collection(vector_size)
 
@@ -106,7 +119,25 @@ class QdrantAdapter:
                 size=vector_size,
                 distance=Distance.COSINE,
             ),
+            sparse_vectors_config={
+                SPARSE_VECTOR_NAME: SparseVectorParams(modifier=Modifier.IDF)
+            },
         )
+        self._sparse_enabled = None
+
+    def sparse_enabled(self) -> bool:
+        """Whether this collection stores BM25 sparse vectors for hybrid search.
+
+        Collections created before hybrid search have no sparse vector
+        configuration, and Qdrant cannot add one to an existing collection.
+        Those collections stay dense-only until they are rebuilt.
+        """
+        if self._sparse_enabled is None:
+            info = self.collection_info()
+            params = getattr(getattr(info, "config", None), "params", None)
+            sparse_vectors = getattr(params, "sparse_vectors", None) or {}
+            self._sparse_enabled = SPARSE_VECTOR_NAME in sparse_vectors
+        return self._sparse_enabled
 
     def collection_info(self):
         try:
@@ -238,6 +269,20 @@ class QdrantAdapter:
                     f"Failed to delete existing chunks for {document_name}: {exc}"
                 ) from exc
 
+    @staticmethod
+    def _point_vector(point: dict):
+        """Return the dense vector, or a named map when sparse data is present."""
+        sparse: SparseVectorData | None = point.get("sparse")
+        if sparse is None:
+            return point["vector"]
+        return {
+            DENSE_VECTOR_NAME: point["vector"],
+            SPARSE_VECTOR_NAME: SparseVector(
+                indices=list(sparse.indices),
+                values=list(sparse.values),
+            ),
+        }
+
     def upsert_points(
         self,
         points: list[dict],
@@ -247,7 +292,7 @@ class QdrantAdapter:
         qdrant_points = [
             PointStruct(
                 id=point["id"],
-                vector=point["vector"],
+                vector=self._point_vector(point),
                 payload=point["payload"],
             )
             for point in points
@@ -292,5 +337,53 @@ class QdrantAdapter:
             )
         return points
 
+    def query_hybrid(
+        self,
+        vector: list[float],
+        sparse: SparseVectorData,
+        *,
+        limit: int,
+        candidate_limit: int | None = None,
+    ):
+        """Fuse dense and BM25 rankings with reciprocal rank fusion in Qdrant."""
+        if not sparse or not self.sparse_enabled():
+            return self.query(vector, limit=limit)
+        if not self.collection_exists():
+            logger.warning(
+                "Qdrant collection %s does not exist; returning zero chunks.",
+                self.collection_name,
+            )
+            return []
+
+        branch_limit = candidate_limit or limit
+        points = self.client.query_points(
+            collection_name=self.collection_name,
+            prefetch=[
+                Prefetch(
+                    query=vector,
+                    using=DENSE_VECTOR_NAME,
+                    limit=branch_limit,
+                ),
+                Prefetch(
+                    query=SparseVector(
+                        indices=list(sparse.indices),
+                        values=list(sparse.values),
+                    ),
+                    using=SPARSE_VECTOR_NAME,
+                    limit=branch_limit,
+                ),
+            ],
+            query=FusionQuery(fusion=Fusion.RRF),
+            limit=limit,
+            with_payload=True,
+        ).points
+        if not points:
+            logger.warning(
+                "Qdrant collection %s exists but the query returned zero chunks.",
+                self.collection_name,
+            )
+        return points
+
     def delete_collection(self) -> None:
         self.client.delete_collection(self.collection_name)
+        self._sparse_enabled = None

--- a/lib/datasets/indexing.py
+++ b/lib/datasets/indexing.py
@@ -18,6 +18,7 @@ from lib.datasets.source import (
     parsed_filepath,
     snapshot_source_files,
 )
+from lib.datasets.sparse import SPARSE_ENCODER_VERSION, encode_document
 from lib.logger import get_logger
 from lib.slugify import slugify
 from lib.storage import get_storage
@@ -47,6 +48,13 @@ async def reconcile_index(
         qdrant.get_document_mtimes(raise_on_error=True)
         if collection_exists
         else {}
+    )
+    # Collections created before hybrid search cannot gain sparse vectors in
+    # place, so they stay dense-only until an explicit rebuild recreates them.
+    sparse_version = (
+        SPARSE_ENCODER_VERSION
+        if not collection_exists or qdrant.sparse_enabled()
+        else ""
     )
 
     indexable_source_names = {
@@ -97,6 +105,7 @@ async def reconcile_index(
                     "indexed_parsed_sha256": parsed_sha,
                     "indexed_chunker_version": CHUNKER_VERSION,
                     "indexed_embedding_model": embeddings.model,
+                    "indexed_sparse_version": sparse_version,
                 }
             )
 
@@ -104,6 +113,7 @@ async def reconcile_index(
             state.get("indexed_parsed_sha256") != parsed_sha
             or state.get("indexed_chunker_version") != CHUNKER_VERSION
             or state.get("indexed_embedding_model") != embeddings.model
+            or state.get("indexed_sparse_version", "") != sparse_version
         ):
             files_to_index.append((source, parsed_path, parsed_text))
 
@@ -140,6 +150,7 @@ async def reconcile_index(
                     embeddings,
                     source.filename,
                     chunks,
+                    with_sparse=bool(sparse_version),
                 )
             state = manifest.state(source.filename)
             state.update(
@@ -147,6 +158,7 @@ async def reconcile_index(
                     "indexed_parsed_sha256": content_hash(text),
                     "indexed_chunker_version": CHUNKER_VERSION,
                     "indexed_embedding_model": embeddings.model,
+                    "indexed_sparse_version": sparse_version,
                 }
             )
             result.indexed += 1
@@ -186,6 +198,8 @@ async def replace_document(
     embeddings: EmbeddingService,
     filename: str,
     chunks,
+    *,
+    with_sparse: bool = False,
 ) -> None:
     """Upsert a complete replacement before removing obsolete chunk IDs."""
     existing_ids = qdrant.get_document_point_ids(filename)
@@ -195,13 +209,14 @@ async def replace_document(
         payload = chunk.model_dump()
         payload.pop("chunk_id", None)
         payload.pop("score", None)
-        points.append(
-            {
-                "id": chunk.chunk_id,
-                "vector": vector,
-                "payload": payload,
-            }
-        )
+        point = {
+            "id": chunk.chunk_id,
+            "vector": vector,
+            "payload": payload,
+        }
+        if with_sparse:
+            point["sparse"] = encode_document(chunk.text)
+        points.append(point)
     qdrant.upsert_points(points)
     qdrant.delete_point_ids(
         existing_ids - {point["id"] for point in points}

--- a/lib/datasets/manifest.py
+++ b/lib/datasets/manifest.py
@@ -105,14 +105,19 @@ class IngestionManifest:
             embedding_model = state.get("indexed_embedding_model")
             if not all((parsed_sha, chunker_version, embedding_model)):
                 continue
-            indexed_documents.append(
-                {
-                    "filename": filename,
-                    "parsed_sha256": parsed_sha,
-                    "chunker_version": chunker_version,
-                    "embedding_model": embedding_model,
-                }
-            )
+            document = {
+                "filename": filename,
+                "parsed_sha256": parsed_sha,
+                "chunker_version": chunker_version,
+                "embedding_model": embedding_model,
+            }
+            # Only recorded once sparse vectors exist, so datasets that have
+            # not been rebuilt for hybrid search keep their current revision
+            # and their reusable insights.
+            sparse_version = state.get("indexed_sparse_version")
+            if sparse_version:
+                document["sparse_version"] = sparse_version
+            indexed_documents.append(document)
 
         self.indexed_dataset_revision = content_hash(
             json.dumps(

--- a/lib/datasets/reranking.py
+++ b/lib/datasets/reranking.py
@@ -1,0 +1,93 @@
+"""Optional cross-encoder reranking of retrieved chunks.
+
+Dense and BM25 retrieval both score a query against a whole chunk in isolation.
+A cross-encoder reads the query and the chunk together, which recovers accuracy
+that a small local embedding model loses on long documents. Reranking is off
+until RERANK_MODEL is configured, and any failure keeps the fusion order.
+"""
+
+from __future__ import annotations
+
+from lib.datasets.models import Chunk
+from lib.logger import get_logger
+from lib.model_config import rerank_endpoint
+from lib.services_gateway import gateway
+
+logger = get_logger(__name__)
+
+
+def reranking_enabled() -> bool:
+    return rerank_endpoint() is not None
+
+
+def _ranked_indices(response) -> list[tuple[int, float | None]]:
+    """Extract (index, score) pairs from a LiteLLM rerank response."""
+    results = getattr(response, "results", None)
+    if results is None and isinstance(response, dict):
+        results = response.get("results")
+
+    ranked: list[tuple[int, float | None]] = []
+    for item in results or []:
+        if isinstance(item, dict):
+            index = item.get("index")
+            score = item.get("relevance_score")
+        else:
+            index = getattr(item, "index", None)
+            score = getattr(item, "relevance_score", None)
+        if isinstance(index, int):
+            ranked.append((index, score))
+    return ranked
+
+
+def _reorder(chunks: list[Chunk], ranked: list[tuple[int, float | None]]) -> list[Chunk]:
+    reordered: list[Chunk] = []
+    seen: set[int] = set()
+    for index, score in ranked:
+        if not 0 <= index < len(chunks) or index in seen:
+            continue
+        seen.add(index)
+        chunk = chunks[index]
+        reordered.append(
+            chunk.model_copy(update={"score": score})
+            if score is not None
+            else chunk
+        )
+    # Chunks the provider did not return keep their fusion order behind the
+    # reranked ones, so reranking can never reduce recall.
+    reordered.extend(
+        chunk for index, chunk in enumerate(chunks) if index not in seen
+    )
+    return reordered
+
+
+async def rerank_chunks(query: str, chunks: list[Chunk]) -> list[Chunk]:
+    """Reorder chunks by cross-encoder relevance when reranking is configured."""
+    endpoint = rerank_endpoint()
+    if endpoint is None or len(chunks) < 2 or not query.strip():
+        return chunks
+
+    kwargs = endpoint.litellm_kwargs()
+    kwargs["query"] = query
+    kwargs["documents"] = [chunk.text for chunk in chunks]
+    kwargs["top_n"] = len(chunks)
+    try:
+        response = await gateway.request_rerank(kwargs)
+    except Exception as exc:
+        logger.warning(
+            "Reranking with %s failed; keeping retrieval order: %s",
+            endpoint.model,
+            exc,
+        )
+        return chunks
+
+    ranked = _ranked_indices(response)
+    if not ranked:
+        logger.warning(
+            "Reranking with %s returned no usable results; "
+            "keeping retrieval order.",
+            endpoint.model,
+        )
+        return chunks
+
+    logger.info("Reranked %s chunks with %s.", len(chunks), endpoint.model)
+    return _reorder(chunks, ranked)

--- a/lib/datasets/retrieval.py
+++ b/lib/datasets/retrieval.py
@@ -1,0 +1,77 @@
+"""Candidate sizing and result diversification for dataset search."""
+
+from __future__ import annotations
+
+import os
+from collections import Counter
+
+from lib.datasets.models import Chunk
+from lib.logger import get_logger
+
+logger = get_logger(__name__)
+
+_DEFAULT_CANDIDATE_MULTIPLIER = 4.0
+_DEFAULT_DOCUMENT_SHARE = 0.4
+_MAX_CANDIDATES = 400
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        logger.warning("Ignoring non-numeric %s=%r.", name, raw)
+        return default
+
+
+def candidate_limit(max_chunks: int) -> int:
+    """Number of chunks to retrieve before reranking and diversification."""
+    multiplier = max(1.0, _env_float(
+        "RETRIEVAL_CANDIDATE_MULTIPLIER",
+        _DEFAULT_CANDIDATE_MULTIPLIER,
+    ))
+    return min(_MAX_CANDIDATES, max(max_chunks, int(max_chunks * multiplier)))
+
+
+def max_chunks_per_document(max_chunks: int) -> int:
+    """Cap on how many of the returned chunks one document may contribute."""
+    share = _env_float(
+        "RETRIEVAL_MAX_DOCUMENT_SHARE",
+        _DEFAULT_DOCUMENT_SHARE,
+    )
+    if share <= 0 or share >= 1:
+        return max_chunks
+    return max(1, round(max_chunks * share))
+
+
+def apply_document_diversity(
+    chunks: list[Chunk],
+    limit: int,
+    max_per_document: int,
+) -> list[Chunk]:
+    """Stop one large document from crowding out the rest of a data room.
+
+    Chunks above the per-document cap are demoted rather than dropped, so the
+    caller still receives as many chunks as were retrieved.
+    """
+    if limit <= 0:
+        return []
+    if max_per_document >= limit:
+        return chunks[:limit]
+
+    selected: list[Chunk] = []
+    demoted: list[Chunk] = []
+    per_document: Counter[str] = Counter()
+    for chunk in chunks:
+        if per_document[chunk.document_name] < max_per_document:
+            per_document[chunk.document_name] += 1
+            selected.append(chunk)
+        else:
+            demoted.append(chunk)
+
+    results = selected[:limit]
+    if len(results) < limit:
+        results.extend(demoted[:limit - len(results)])
+    return results

--- a/lib/datasets/search.py
+++ b/lib/datasets/search.py
@@ -3,6 +3,13 @@
 from lib.datasets.embeddings import EmbeddingService
 from lib.datasets.ingestion import sync_datasets
 from lib.datasets.models import Chunk
+from lib.datasets.reranking import rerank_chunks
+from lib.datasets.retrieval import (
+    apply_document_diversity,
+    candidate_limit,
+    max_chunks_per_document,
+)
+from lib.datasets.sparse import encode_query
 from lib.adapters.qdrant import QdrantAdapter
 from lib.logger import get_logger
 from lib.slugify import slugify
@@ -10,44 +17,32 @@ from lib.slugify import slugify
 logger = get_logger(__name__)
 
 
-async def dataset_search(
-    dataset_name: str,
-    query: str | list[str] = "",
-    max_chunks: int = 25,
-    raise_on_error: bool = False,
-) -> list[Chunk]:
-    """Unified API to run semantic search and retrieve dataset chunks."""
-    dataset_slug = slugify(dataset_name)
-    await sync_datasets([dataset_slug], raise_on_error=True)
-    queries = (
-        [query.strip()]
-        if isinstance(query, str) and query.strip()
-        else [item.strip() for item in query if item.strip()]
-        if not isinstance(query, str)
-        else []
-    )
-    if not queries or max_chunks <= 0:
-        return []
+def _normalize_queries(query: str | list[str]) -> list[str]:
+    if isinstance(query, str):
+        stripped = query.strip()
+        return [stripped] if stripped else []
+    return [item.strip() for item in query if item.strip()]
 
-    try:
-        embeddings = EmbeddingService()
-        vectors = await embeddings.embed_many(queries)
-        qdrant = QdrantAdapter(dataset_slug)
-        result_lists = [
-            qdrant.query(vector, limit=max_chunks)
-            for vector in vectors
-        ]
-    except Exception as exc:
-        logger.exception("Semantic search failed for dataset '%s'.", dataset_slug)
-        if raise_on_error:
-            raise RuntimeError(
-                f"Semantic search failed for dataset '{dataset_slug}': {exc}"
-            ) from exc
-        return []
 
-    chunks = []
-    seen_chunk_ids = set()
-    for index in range(max_chunks):
+def _retrieve(
+    qdrant: QdrantAdapter,
+    text: str,
+    vector: list[float],
+    *,
+    limit: int,
+    hybrid: bool,
+) -> list:
+    if hybrid:
+        return qdrant.query_hybrid(vector, encode_query(text), limit=limit)
+    return qdrant.query(vector, limit=limit)
+
+
+def _merge_result_lists(result_lists: list, limit: int) -> list[Chunk]:
+    """Interleave per-question results so every question keeps its best hits."""
+    chunks: list[Chunk] = []
+    seen_chunk_ids: set[str] = set()
+    depth = max((len(results) for results in result_lists), default=0)
+    for index in range(depth):
         for results in result_lists:
             if index >= len(results):
                 continue
@@ -59,9 +54,63 @@ async def dataset_search(
             payload = dict(result.payload or {})
             payload["chunk_id"] = chunk_id
             payload["score"] = result.score
-            chunks.append(
-                Chunk.model_validate(payload)
-            )
-            if len(chunks) >= max_chunks:
+            chunks.append(Chunk.model_validate(payload))
+            if len(chunks) >= limit:
                 return chunks
     return chunks
+
+
+async def dataset_search(
+    dataset_name: str,
+    query: str | list[str] = "",
+    max_chunks: int = 25,
+    raise_on_error: bool = False,
+) -> list[Chunk]:
+    """Unified API to run semantic search and retrieve dataset chunks.
+
+    Retrieval runs wide, then narrows: dense and BM25 rankings are fused in
+    Qdrant, an optional cross-encoder reranks the candidates, and a
+    per-document cap keeps one large document from filling the whole result.
+    """
+    dataset_slug = slugify(dataset_name)
+    await sync_datasets([dataset_slug], raise_on_error=True)
+    queries = _normalize_queries(query)
+    if not queries or max_chunks <= 0:
+        return []
+
+    candidates = candidate_limit(max_chunks)
+    try:
+        embeddings = EmbeddingService()
+        vectors = await embeddings.embed_many(queries)
+        qdrant = QdrantAdapter(dataset_slug)
+        hybrid = qdrant.sparse_enabled()
+        if not hybrid and qdrant.collection_exists():
+            logger.info(
+                "Collection %s has no BM25 vectors; using dense-only search. "
+                "Run 'dataset_maintenance rebuild-index --dataset %s' to "
+                "enable hybrid search.",
+                qdrant.collection_name,
+                dataset_slug,
+            )
+        result_lists = [
+            _retrieve(qdrant, text, vector, limit=candidates, hybrid=hybrid)
+            for text, vector in zip(queries, vectors)
+        ]
+    except Exception as exc:
+        logger.exception("Semantic search failed for dataset '%s'.", dataset_slug)
+        if raise_on_error:
+            raise RuntimeError(
+                f"Semantic search failed for dataset '{dataset_slug}': {exc}"
+            ) from exc
+        return []
+
+    chunks = _merge_result_lists(result_lists, candidates)
+    if not chunks:
+        return []
+
+    chunks = await rerank_chunks("\n\n".join(queries), chunks)
+    return apply_document_diversity(
+        chunks,
+        max_chunks,
+        max_chunks_per_document(max_chunks),
+    )

--- a/lib/datasets/sparse.py
+++ b/lib/datasets/sparse.py
@@ -1,0 +1,104 @@
+"""BM25 sparse vector encoding for hybrid retrieval.
+
+Qdrant applies the inverse document frequency through the IDF modifier on the
+sparse vector configuration, so only the term-frequency component of BM25 is
+encoded here. Token identifiers are content hashes, which keeps the encoder
+stateless and therefore consistent across processes and machines.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from collections import Counter
+from dataclasses import dataclass, field
+
+SPARSE_ENCODER_VERSION = "bm25-v1"
+
+_K1 = 1.2
+_B = 0.75
+# Reference document length in tokens used for BM25 length normalization.
+# Chunks are capped at 1000 characters, which averages out near this value.
+_AVERAGE_DOCUMENT_TOKENS = 120.0
+
+_TOKEN_PATTERN = re.compile(r"\w+", re.UNICODE)
+_MIN_TOKEN_LENGTH = 2
+_MAX_TOKEN_LENGTH = 40
+
+# Function words carry almost no retrieval signal. Qdrant's IDF modifier would
+# already downweight them; dropping them here keeps the sparse index smaller.
+_STOPWORDS = frozenset(
+    """
+    a an and are as at be been but by for from had has have he her his if in
+    into is it its of on or she that the their them there these they this to
+    was were which who will with would you your
+    aber alle als am auch auf aus bei bin bis das dass dem den der des die dies
+    ein eine einer eines er es fuer für hat haben ich ihre im ist mit nach nicht
+    noch nur oder sich sie sind über und uns vom von vor war werden wie wir zu
+    zum zur
+    au aux avec ce ces dans de des du elle en est et il la le les leur mais ne
+    nous ou par pas pour que qui sa se ses son sur un une vous
+    """.split()
+)
+
+
+@dataclass(frozen=True)
+class SparseVectorData:
+    """Sparse vector as parallel index and value lists, sorted by index."""
+
+    indices: list[int] = field(default_factory=list)
+    values: list[float] = field(default_factory=list)
+
+    def __bool__(self) -> bool:
+        return bool(self.indices)
+
+
+def tokenize(text: str) -> list[str]:
+    """Split text into lowercase content tokens."""
+    tokens = []
+    for token in _TOKEN_PATTERN.findall(text.lower()):
+        if not _MIN_TOKEN_LENGTH <= len(token) <= _MAX_TOKEN_LENGTH:
+            continue
+        if token in _STOPWORDS:
+            continue
+        tokens.append(token)
+    return tokens
+
+
+def token_id(token: str) -> int:
+    """Map a token to a stable unsigned 32-bit sparse vector index."""
+    digest = hashlib.blake2b(token.encode("utf-8"), digest_size=4).digest()
+    return int.from_bytes(digest, "big")
+
+
+def _to_sparse_vector(weights: dict[int, float]) -> SparseVectorData:
+    if not weights:
+        return SparseVectorData()
+    indices = sorted(weights)
+    return SparseVectorData(
+        indices=indices,
+        values=[weights[index] for index in indices],
+    )
+
+
+def encode_document(text: str) -> SparseVectorData:
+    """Encode indexed text as BM25 term-frequency weights."""
+    tokens = tokenize(text)
+    if not tokens:
+        return SparseVectorData()
+
+    length_penalty = _K1 * (
+        1 - _B + _B * len(tokens) / _AVERAGE_DOCUMENT_TOKENS
+    )
+    weights: dict[int, float] = {}
+    for token, frequency in Counter(tokens).items():
+        weight = frequency * (_K1 + 1) / (frequency + length_penalty)
+        index = token_id(token)
+        weights[index] = weights.get(index, 0.0) + weight
+    return _to_sparse_vector(weights)
+
+
+def encode_query(text: str) -> SparseVectorData:
+    """Encode a query as unit weights over its distinct tokens."""
+    weights = {token_id(token): 1.0 for token in tokenize(text)}
+    return _to_sparse_vector(weights)

--- a/lib/model_config.py
+++ b/lib/model_config.py
@@ -66,6 +66,18 @@ def embedding_endpoint() -> ModelEndpoint:
     )
 
 
+def rerank_endpoint() -> Optional[ModelEndpoint]:
+    """Cross-encoder reranking endpoint, or None when reranking is disabled."""
+    model = _optional_env("RERANK_MODEL")
+    if not model:
+        return None
+    return ModelEndpoint(
+        model=model,
+        base_url=_first_env("RERANK_BASE_URL"),
+        api_key=_first_env("RERANK_API_KEY"),
+    )
+
+
 def llm_model() -> str:
     return llm_endpoint().model
 

--- a/lib/services_gateway.py
+++ b/lib/services_gateway.py
@@ -18,7 +18,7 @@ from lib.logger import get_logger
 
 logger = get_logger(__name__)
 
-_RESOURCE_KEYS = ("docling", "embedding", "llm")
+_RESOURCE_KEYS = ("docling", "embedding", "llm", "rerank")
 _DEFAULT_WAIT_TIMEOUT = 3600.0
 _POLL_INTERVAL = 0.05
 # A lease held longer than this is treated as leaked and reclaimed even if
@@ -27,6 +27,7 @@ _POLL_INTERVAL = 0.05
 _DEFAULT_LEASE_MAX_AGE = 1800.0
 _DEFAULT_LLM_REQUEST_TIMEOUT = 600.0
 _DEFAULT_EMBEDDING_REQUEST_TIMEOUT = 300.0
+_DEFAULT_RERANK_REQUEST_TIMEOUT = 120.0
 _MAX_CONCURRENT_LLMS = 8
 
 
@@ -156,7 +157,7 @@ class ServicesGateway:
 
     def _empty_state(self) -> dict:
         return {
-            "version": 4,
+            "version": 5,
             "leases": {resource: [] for resource in _RESOURCE_KEYS},
             "requests": {resource: [] for resource in _RESOURCE_KEYS},
         }
@@ -338,11 +339,16 @@ class ServicesGateway:
         *,
         active_models: set[str] | None = None,
     ) -> str:
-        labels = {"docling": "docling", "embedding": "embedding", "llm": "LLM"}
+        labels = {
+            "docling": "docling",
+            "embedding": "embedding",
+            "llm": "LLM",
+            "rerank": "rerank",
+        }
         summary = " | ".join(
             f"{labels[resource]} {counts[resource]['running']} running, "
             f"{counts[resource]['waiting']} waiting"
-            for resource in ("llm", "embedding", "docling")
+            for resource in ("llm", "embedding", "rerank", "docling")
         )
         if active_models is not None:
             summary = (
@@ -597,6 +603,30 @@ class ServicesGateway:
             timeout=timeout,
         ):
             return await litellm.acompletion(**kwargs)
+
+    async def request_rerank(
+        self,
+        kwargs: dict[str, Any],
+        *,
+        timeout: float | None = None,
+    ) -> Any:
+        """Coordinate reranking by model slots and per-model parallelism."""
+        import litellm
+
+        litellm.disable_aiohttp_transport = True
+        kwargs.setdefault(
+            "timeout",
+            _float_env(
+                "RERANK_REQUEST_TIMEOUT",
+                _DEFAULT_RERANK_REQUEST_TIMEOUT,
+            ),
+        )
+        async with self.slot(
+            "rerank",
+            model=str(kwargs.get("model") or "rerank"),
+            timeout=timeout,
+        ):
+            return await litellm.arerank(**kwargs)
 
 
 class _DefaultGateway:

--- a/skills/dataset_maintenance/SKILL.md
+++ b/skills/dataset_maintenance/SKILL.md
@@ -16,6 +16,8 @@ python -m skills.dataset_maintenance diagnose
 python -m skills.dataset_maintenance prune
 python -m skills.dataset_maintenance prune --apply
 python -m skills.dataset_maintenance delete --dataset avientus
+python -m skills.dataset_maintenance rebuild-index --dataset avientus
+python -m skills.dataset_maintenance rebuild-index --dataset avientus --no-sync
 python -m skills.dataset_maintenance activate --dataset avientus
 python -m skills.dataset_maintenance archive --dataset avientus
 python -m skills.dataset_maintenance create "Example Startup"
@@ -33,3 +35,8 @@ creates raw and parsed startup dataset folders with `data-room`, `linkedin`,
 `dealum`, `snippets`, and `post-deal` subfolders, then marks the startup active.
 The startup-dossier migration is also dry-run by default and writes a JSON
 manifest before any optional `--apply`.
+
+`rebuild-index` drops a dataset's Qdrant collection and re-indexes it. Use it to
+give a dataset indexed before hybrid search its BM25 vectors, since Qdrant
+cannot add sparse vectors to an existing collection. Parsed Markdown is kept, so
+the rebuild re-embeds but never re-parses.

--- a/skills/dataset_maintenance/__main__.py
+++ b/skills/dataset_maintenance/__main__.py
@@ -5,6 +5,7 @@ from typing import Optional
 import typer
 
 from lib.cli import run_command
+from lib.datasets.ingestion import sync_datasets
 from lib.insights import dataset_from_insight
 from lib.logger import get_logger
 from skills.dataset_maintenance.maintenance import (
@@ -13,6 +14,7 @@ from skills.dataset_maintenance.maintenance import (
     delete_dataset_index,
     diagnose_qdrant_collections,
     prune_orphaned_qdrant_collections,
+    rebuild_dataset_index,
 )
 from lib.startups.dossier import ensure_startup_dossier
 from skills.dataset_maintenance.startup_dossiers import migrate_startup_dossiers
@@ -73,6 +75,46 @@ def delete_command(
     )
     for collection in collections:
         typer.echo(f"Deleted: {collection}")
+
+
+@app.command("rebuild-index")
+def rebuild_index_command(
+    dataset: str = typer.Option(..., "--dataset", "-d"),
+    embeddings: Optional[str] = typer.Option(None, "--embeddings", "-e"),
+    sync: bool = typer.Option(
+        True,
+        "--sync/--no-sync",
+        help="Re-index immediately after dropping the collection.",
+    ),
+) -> None:
+    """Recreate a dataset index so it gains BM25 vectors for hybrid search."""
+    rebuilds = run_command(
+        lambda: [
+            rebuild_dataset_index(item, embeddings)
+            for item in _parse_datasets(dataset)
+        ],
+        logger=logger,
+        error_prefix="Rebuild failed",
+    )
+    for rebuild in rebuilds:
+        typer.echo(
+            f"Reset: {rebuild.dataset} (collection={rebuild.collection}, "
+            f"deleted={rebuild.collection_deleted}, "
+            f"documents={rebuild.documents_reset})"
+        )
+    if not sync:
+        typer.echo("Skipped re-indexing. Run a sync to rebuild the index.")
+        return
+    run_command(
+        lambda: sync_datasets(
+            [rebuild.dataset for rebuild in rebuilds],
+            raise_on_error=True,
+        ),
+        logger=logger,
+        error_prefix="Rebuild sync failed",
+    )
+    for rebuild in rebuilds:
+        typer.echo(f"Rebuilt index: {rebuild.dataset}")
 
 
 @app.command("activate")

--- a/skills/dataset_maintenance/maintenance.py
+++ b/skills/dataset_maintenance/maintenance.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import Optional
 
 from lib.adapters.qdrant import QdrantAdapter, QdrantAdmin
+from lib.datasets.manifest import IngestionManifest
 from lib.logger import get_logger
 from lib.model_config import embedding_model
 from lib.slugify import slugify
@@ -13,12 +14,28 @@ from lib.datasets.state import activate_dataset, archive_dataset
 
 logger = get_logger(__name__)
 
+# Cleared when an index is rebuilt so reconciliation re-embeds every document.
+_INDEX_STATE_KEYS = (
+    "indexed_parsed_sha256",
+    "indexed_chunker_version",
+    "indexed_embedding_model",
+    "indexed_sparse_version",
+)
+
 
 @dataclass(frozen=True)
 class CollectionDiagnostic:
     collection: str
     dataset: str
     status: str
+
+
+@dataclass(frozen=True)
+class IndexRebuild:
+    dataset: str
+    collection: str
+    collection_deleted: bool
+    documents_reset: int
 
 
 def orphaned_qdrant_collections(
@@ -127,6 +144,50 @@ def delete_dataset_index(
     for collection in deleted:
         admin.delete_collection(collection)
     return deleted
+
+
+def rebuild_dataset_index(
+    dataset: str,
+    embeddings: Optional[str] = None,
+) -> IndexRebuild:
+    """Drop a dataset's Qdrant collection so the next sync rebuilds it.
+
+    Qdrant cannot add sparse vectors to an existing collection, so datasets
+    indexed before hybrid search need their collection recreated. Parsed
+    Markdown is kept, which means the rebuild re-embeds but never re-parses.
+    """
+    if not dataset:
+        raise ValueError("Must provide --dataset/-d.")
+
+    dataset_slug = slugify(dataset)
+    collection = QdrantAdapter.collection_for(dataset_slug, embeddings)
+    admin = QdrantAdmin()
+    collection_deleted = collection in admin.list_collections()
+    if collection_deleted:
+        admin.delete_collection(collection)
+        logger.info("Deleted Qdrant collection for rebuild: %s", collection)
+
+    manifest = IngestionManifest.load(
+        get_storage(),
+        dataset_parsed_path(dataset_slug),
+    )
+    documents_reset = 0
+    for state in manifest.documents.values():
+        if not any(key in state for key in _INDEX_STATE_KEYS):
+            continue
+        for key in _INDEX_STATE_KEYS:
+            state.pop(key, None)
+        documents_reset += 1
+    if documents_reset:
+        manifest.indexed_dataset_revision = ""
+        manifest.save()
+
+    return IndexRebuild(
+        dataset=dataset_slug,
+        collection=collection,
+        collection_deleted=collection_deleted,
+        documents_reset=documents_reset,
+    )
 
 
 def activate_dataset_marker(dataset: str) -> str:

--- a/tests/dataset_chat/test_dataset_search.py
+++ b/tests/dataset_chat/test_dataset_search.py
@@ -5,52 +5,76 @@ from lib.datasets.search import dataset_search
 from lib.datasets.source import parsed_filepath
 
 
-@pytest.mark.asyncio
-async def test_dataset_search_embeds_query_and_passes_limit_to_qdrant(mocker):
-    mocker.patch("lib.datasets.search.sync_datasets")
-    mock_adapter = mocker.patch("lib.datasets.search.QdrantAdapter")
-    embedding_service = mocker.patch(
-        "lib.datasets.search.EmbeddingService"
+def _point(point_id, document_name="report.pdf", score=0.9):
+    return SimpleNamespace(
+        id=point_id,
+        score=score,
+        payload={
+            "chunk_id": f"payload-{point_id}",
+            "document_name": document_name,
+            "page_number": 1,
+            "last_modified": 1.0,
+            "text": f"Text for {point_id}",
+            "score": None,
+        },
     )
+
+
+@pytest.fixture
+def search_backend(mocker):
+    """Patch sync, embeddings, and Qdrant for dataset_search unit tests."""
+    mocker.patch("lib.datasets.search.sync_datasets")
+    adapter = mocker.patch("lib.datasets.search.QdrantAdapter")
+    embedding_service = mocker.patch("lib.datasets.search.EmbeddingService")
     embedding_service.return_value.embed_many = mocker.AsyncMock(
         return_value=[[1.0, 2.0]]
     )
-    mock_adapter.return_value.query.return_value = []
+    adapter.return_value.sparse_enabled.return_value = True
+    adapter.return_value.query_hybrid.return_value = []
+    adapter.return_value.query.return_value = []
+    return SimpleNamespace(adapter=adapter, embeddings=embedding_service)
+
+
+@pytest.mark.asyncio
+async def test_dataset_search_fuses_dense_and_sparse_over_candidate_pool(
+    search_backend,
+):
+    await dataset_search("Avientus", "patent assignment", max_chunks=25)
+
+    search_backend.embeddings.return_value.embed_many.assert_awaited_once_with(
+        ["patent assignment"]
+    )
+    search_backend.adapter.return_value.query.assert_not_called()
+    call = search_backend.adapter.return_value.query_hybrid.call_args
+    assert call.args[0] == [1.0, 2.0]
+    # BM25 terms are derived from the query text, not the embedding.
+    assert call.args[1].indices
+    # Retrieval runs wider than the requested chunk count so that reranking
+    # and the per-document cap have candidates to work with.
+    assert call.kwargs["limit"] == 100
+
+
+@pytest.mark.asyncio
+async def test_dataset_search_falls_back_to_dense_for_legacy_collections(
+    search_backend,
+):
+    search_backend.adapter.return_value.sparse_enabled.return_value = False
 
     await dataset_search("Avientus", "profile query", max_chunks=25)
 
-    embedding_service.return_value.embed_many.assert_awaited_once_with(
-        ["profile query"]
-    )
-    mock_adapter.return_value.query.assert_called_once_with(
+    search_backend.adapter.return_value.query_hybrid.assert_not_called()
+    search_backend.adapter.return_value.query.assert_called_once_with(
         [1.0, 2.0],
-        limit=25,
+        limit=100,
     )
 
 
 @pytest.mark.asyncio
-async def test_dataset_search_normalizes_ids_from_legacy_and_current_payloads(mocker):
-    mocker.patch("lib.datasets.search.sync_datasets")
-    mock_adapter = mocker.patch("lib.datasets.search.QdrantAdapter")
-    embedding_service = mocker.patch(
-        "lib.datasets.search.EmbeddingService"
-    )
-    embedding_service.return_value.embed_many = mocker.AsyncMock(
-        return_value=[[1.0, 2.0]]
-    )
-    mock_adapter.return_value.query.return_value = [
-        SimpleNamespace(
-            id="point-id",
-            score=0.91,
-            payload={
-                "chunk_id": "payload-id",
-                "document_name": "report.pdf",
-                "page_number": 1,
-                "last_modified": 1.0,
-                "text": "Relevant text",
-                "score": None,
-            },
-        )
+async def test_dataset_search_normalizes_ids_from_legacy_and_current_payloads(
+    search_backend,
+):
+    search_backend.adapter.return_value.query_hybrid.return_value = [
+        _point("point-id", score=0.91)
     ]
 
     chunks = await dataset_search("Avientus", "profile query", max_chunks=25)
@@ -61,12 +85,62 @@ async def test_dataset_search_normalizes_ids_from_legacy_and_current_payloads(mo
 
 
 @pytest.mark.asyncio
-async def test_dataset_search_can_raise_after_logging_failures(mocker):
-    mocker.patch("lib.datasets.search.sync_datasets")
-    embedding_service = mocker.patch(
-        "lib.datasets.search.EmbeddingService"
+async def test_dataset_search_caps_one_document_from_filling_the_result(
+    search_backend,
+):
+    search_backend.adapter.return_value.query_hybrid.return_value = [
+        _point(f"big-{index}", document_name="master-agreement.pdf")
+        for index in range(6)
+    ] + [
+        _point("other-1", document_name="cap-table.xlsx"),
+        _point("other-2", document_name="patent-register.pdf"),
+    ]
+
+    chunks = await dataset_search("Avientus", "ownership", max_chunks=4)
+
+    documents = [chunk.document_name for chunk in chunks]
+    assert len(chunks) == 4
+    assert documents.count("master-agreement.pdf") == 2
+    assert "cap-table.xlsx" in documents
+    assert "patent-register.pdf" in documents
+
+
+@pytest.mark.asyncio
+async def test_dataset_search_keeps_requested_count_when_one_document_matches(
+    search_backend,
+):
+    search_backend.adapter.return_value.query_hybrid.return_value = [
+        _point(f"only-{index}", document_name="single.pdf")
+        for index in range(5)
+    ]
+
+    chunks = await dataset_search("Avientus", "ownership", max_chunks=4)
+
+    assert len(chunks) == 4
+
+
+@pytest.mark.asyncio
+async def test_dataset_search_applies_reranked_order(search_backend, mocker):
+    search_backend.adapter.return_value.query_hybrid.return_value = [
+        _point("first", document_name="a.pdf"),
+        _point("second", document_name="b.pdf"),
+    ]
+    mocker.patch(
+        "lib.datasets.search.rerank_chunks",
+        new=mocker.AsyncMock(side_effect=lambda _query, chunks: chunks[::-1]),
     )
-    embedding_service.return_value.embed_many = mocker.AsyncMock(
+
+    chunks = await dataset_search("Avientus", "profile query", max_chunks=2)
+
+    assert [chunk.chunk_id for chunk in chunks] == ["second", "first"]
+
+
+@pytest.mark.asyncio
+async def test_dataset_search_can_raise_after_logging_failures(
+    search_backend,
+    mocker,
+):
+    search_backend.embeddings.return_value.embed_many = mocker.AsyncMock(
         side_effect=RuntimeError("embedding service unavailable")
     )
     logged = mocker.patch("lib.datasets.search.logger.exception")

--- a/tests/dataset_chat/test_ingestion_sparse.py
+++ b/tests/dataset_chat/test_ingestion_sparse.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from lib.datasets import indexing, source
+from lib.datasets.indexing import replace_document
+from lib.datasets.manifest import (
+    CHUNKER_VERSION,
+    PARSER_VERSION,
+    IngestionManifest,
+    content_hash,
+)
+from lib.datasets.sparse import SPARSE_ENCODER_VERSION, token_id
+from lib.storage import LocalStorage
+
+
+class _Embeddings:
+    model = "test-model"
+
+    async def embed_many(self, texts):
+        return [[1.0] for _ in texts]
+
+    def vector_size(self):
+        return 1
+
+
+def _chunk(chunk_id: str, text: str):
+    return SimpleNamespace(
+        chunk_id=chunk_id,
+        text=text,
+        model_dump=lambda: {"document_name": "report.pdf", "text": text},
+    )
+
+
+@pytest.mark.asyncio
+async def test_replacement_omits_sparse_vectors_by_default():
+    captured = {}
+    qdrant = SimpleNamespace(
+        get_document_point_ids=lambda _name: set(),
+        upsert_points=lambda points: captured.setdefault("points", points),
+        delete_point_ids=lambda _ids: None,
+    )
+
+    await replace_document(
+        qdrant,
+        _Embeddings(),
+        "report.pdf",
+        [_chunk("chunk-1", "patent assignment")],
+    )
+
+    assert "sparse" not in captured["points"][0]
+
+
+@pytest.mark.asyncio
+async def test_replacement_attaches_bm25_vectors_for_hybrid_collections():
+    captured = {}
+    qdrant = SimpleNamespace(
+        get_document_point_ids=lambda _name: set(),
+        upsert_points=lambda points: captured.setdefault("points", points),
+        delete_point_ids=lambda _ids: None,
+    )
+
+    await replace_document(
+        qdrant,
+        _Embeddings(),
+        "report.pdf",
+        [_chunk("chunk-1", "patent assignment")],
+        with_sparse=True,
+    )
+
+    sparse = captured["points"][0]["sparse"]
+    assert token_id("patent") in sparse.indices
+    assert token_id("assignment") in sparse.indices
+
+
+def _indexed_dataset(tmp_path, mocker, *, sparse_state: str | None):
+    storage = LocalStorage(tmp_path)
+    raw_rel = "datasets/example"
+    parsed_rel = "cache/datasets2md/example"
+    storage.write_text(f"{raw_rel}/report.md", "parsed body")
+    storage.write_text(f"{parsed_rel}/report.md", "parsed body")
+    source_document = source.snapshot_source_files(storage, raw_rel)[0]
+
+    manifest = IngestionManifest(storage, parsed_rel)
+    state = {
+        "source_sha256": source_document.sha256,
+        "source_mtime": source_document.mtime,
+        "parsed_sha256": content_hash("parsed body"),
+        "parser_version": PARSER_VERSION,
+        "indexed_parsed_sha256": content_hash("parsed body"),
+        "indexed_chunker_version": CHUNKER_VERSION,
+        "indexed_embedding_model": "test-model",
+    }
+    if sparse_state is not None:
+        state["indexed_sparse_version"] = sparse_state
+    manifest.documents["report.md"] = state
+    manifest.save()
+    mocker.patch.object(indexing, "get_storage", return_value=storage)
+    mocker.patch.object(indexing, "EmbeddingService", return_value=_Embeddings())
+    return storage, raw_rel, parsed_rel, manifest, source_document
+
+
+@pytest.mark.asyncio
+async def test_dense_only_collections_are_left_untouched(tmp_path, mocker):
+    storage, raw_rel, parsed_rel, manifest, document = _indexed_dataset(
+        tmp_path,
+        mocker,
+        sparse_state=None,
+    )
+    qdrant = mocker.Mock()
+    qdrant.collection_exists.return_value = True
+    qdrant.sparse_enabled.return_value = False
+    qdrant.get_document_mtimes.return_value = {"report.md": document.mtime}
+    mocker.patch.object(indexing, "QdrantAdapter", return_value=qdrant)
+    replace = mocker.patch.object(indexing, "replace_document")
+
+    result = await indexing.reconcile_index(
+        "example",
+        raw_rel,
+        parsed_rel,
+        sources=[document],
+        manifest=manifest,
+    )
+
+    # Rebuilding a legacy collection would re-embed the whole dataset, so it
+    # only happens on an explicit rebuild.
+    assert result.indexed == 0
+    replace.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_missing_sparse_vectors_trigger_reindexing(tmp_path, mocker):
+    storage, raw_rel, parsed_rel, manifest, document = _indexed_dataset(
+        tmp_path,
+        mocker,
+        sparse_state=None,
+    )
+    qdrant = mocker.Mock()
+    qdrant.collection_exists.return_value = True
+    qdrant.sparse_enabled.return_value = True
+    qdrant.get_document_mtimes.return_value = {"report.md": document.mtime}
+    mocker.patch.object(indexing, "QdrantAdapter", return_value=qdrant)
+    replace = mocker.patch.object(indexing, "replace_document")
+
+    result = await indexing.reconcile_index(
+        "example",
+        raw_rel,
+        parsed_rel,
+        sources=[document],
+        manifest=manifest,
+    )
+
+    assert result.indexed == 1
+    assert replace.call_args.kwargs["with_sparse"] is True
+    loaded = IngestionManifest.load(storage, parsed_rel)
+    assert (
+        loaded.documents["report.md"]["indexed_sparse_version"]
+        == SPARSE_ENCODER_VERSION
+    )
+
+
+@pytest.mark.asyncio
+async def test_current_sparse_index_is_not_rebuilt(tmp_path, mocker):
+    _storage, raw_rel, parsed_rel, manifest, document = _indexed_dataset(
+        tmp_path,
+        mocker,
+        sparse_state=SPARSE_ENCODER_VERSION,
+    )
+    qdrant = mocker.Mock()
+    qdrant.collection_exists.return_value = True
+    qdrant.sparse_enabled.return_value = True
+    qdrant.get_document_mtimes.return_value = {"report.md": document.mtime}
+    mocker.patch.object(indexing, "QdrantAdapter", return_value=qdrant)
+    replace = mocker.patch.object(indexing, "replace_document")
+
+    result = await indexing.reconcile_index(
+        "example",
+        raw_rel,
+        parsed_rel,
+        sources=[document],
+        manifest=manifest,
+    )
+
+    assert result.indexed == 0
+    replace.assert_not_called()

--- a/tests/dataset_chat/test_reranking.py
+++ b/tests/dataset_chat/test_reranking.py
@@ -1,0 +1,153 @@
+from types import SimpleNamespace
+
+import pytest
+
+from lib.datasets import reranking
+from lib.datasets.models import Chunk
+from lib.datasets.reranking import rerank_chunks, reranking_enabled
+
+
+def _chunk(chunk_id: str) -> Chunk:
+    return Chunk(
+        chunk_id=chunk_id,
+        document_name=f"{chunk_id}.pdf",
+        page_number=1,
+        last_modified=0.0,
+        text=f"text {chunk_id}",
+        score=0.5,
+    )
+
+
+@pytest.fixture
+def enabled_reranker(monkeypatch):
+    monkeypatch.setenv("RERANK_MODEL", "infinity/BAAI/bge-reranker-v2-m3")
+    monkeypatch.setenv("RERANK_BASE_URL", "http://localhost:7997")
+    monkeypatch.setenv("RERANK_API_KEY", "")
+
+
+def _response(*entries):
+    return SimpleNamespace(
+        results=[
+            {"index": index, "relevance_score": score}
+            for index, score in entries
+        ]
+    )
+
+
+def test_reranking_is_disabled_without_a_configured_model(monkeypatch):
+    monkeypatch.delenv("RERANK_MODEL", raising=False)
+
+    assert reranking_enabled() is False
+
+
+def test_reranking_is_enabled_once_configured(enabled_reranker):
+    assert reranking_enabled() is True
+
+
+@pytest.mark.asyncio
+async def test_rerank_is_skipped_when_disabled(monkeypatch, mocker):
+    monkeypatch.delenv("RERANK_MODEL", raising=False)
+    request = mocker.patch.object(
+        reranking.gateway,
+        "request_rerank",
+        new=mocker.AsyncMock(),
+    )
+    chunks = [_chunk("a"), _chunk("b")]
+
+    assert await rerank_chunks("query", chunks) == chunks
+    request.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_rerank_reorders_chunks_and_records_scores(
+    enabled_reranker,
+    mocker,
+):
+    mocker.patch.object(
+        reranking.gateway,
+        "request_rerank",
+        new=mocker.AsyncMock(return_value=_response((2, 0.9), (0, 0.4))),
+    )
+    chunks = [_chunk("a"), _chunk("b"), _chunk("c")]
+
+    reranked = await rerank_chunks("query", chunks)
+
+    # Reranked hits come first; chunks the provider omitted keep their order
+    # behind them so reranking cannot drop recall.
+    assert [chunk.chunk_id for chunk in reranked] == ["c", "a", "b"]
+    assert reranked[0].score == 0.9
+    assert reranked[1].score == 0.4
+    assert reranked[2].score == 0.5
+
+
+@pytest.mark.asyncio
+async def test_rerank_sends_query_and_chunk_texts(enabled_reranker, mocker):
+    request = mocker.patch.object(
+        reranking.gateway,
+        "request_rerank",
+        new=mocker.AsyncMock(return_value=_response((0, 1.0), (1, 0.1))),
+    )
+
+    await rerank_chunks("patent ownership", [_chunk("a"), _chunk("b")])
+
+    kwargs = request.await_args.args[0]
+    assert kwargs["model"] == "infinity/BAAI/bge-reranker-v2-m3"
+    assert kwargs["api_base"] == "http://localhost:7997"
+    assert kwargs["query"] == "patent ownership"
+    assert kwargs["documents"] == ["text a", "text b"]
+
+
+@pytest.mark.asyncio
+async def test_rerank_keeps_retrieval_order_when_the_provider_fails(
+    enabled_reranker,
+    mocker,
+):
+    mocker.patch.object(
+        reranking.gateway,
+        "request_rerank",
+        new=mocker.AsyncMock(side_effect=RuntimeError("reranker unreachable")),
+    )
+    chunks = [_chunk("a"), _chunk("b")]
+
+    assert await rerank_chunks("query", chunks) == chunks
+
+
+@pytest.mark.asyncio
+async def test_rerank_ignores_out_of_range_indices(enabled_reranker, mocker):
+    mocker.patch.object(
+        reranking.gateway,
+        "request_rerank",
+        new=mocker.AsyncMock(return_value=_response((7, 0.9), (1, 0.8))),
+    )
+    chunks = [_chunk("a"), _chunk("b")]
+
+    reranked = await rerank_chunks("query", chunks)
+
+    assert [chunk.chunk_id for chunk in reranked] == ["b", "a"]
+
+
+@pytest.mark.asyncio
+async def test_rerank_keeps_order_for_an_empty_result_set(
+    enabled_reranker,
+    mocker,
+):
+    mocker.patch.object(
+        reranking.gateway,
+        "request_rerank",
+        new=mocker.AsyncMock(return_value=SimpleNamespace(results=[])),
+    )
+    chunks = [_chunk("a"), _chunk("b")]
+
+    assert await rerank_chunks("query", chunks) == chunks
+
+
+@pytest.mark.asyncio
+async def test_rerank_skips_single_chunk_results(enabled_reranker, mocker):
+    request = mocker.patch.object(
+        reranking.gateway,
+        "request_rerank",
+        new=mocker.AsyncMock(),
+    )
+
+    assert len(await rerank_chunks("query", [_chunk("a")])) == 1
+    request.assert_not_awaited()

--- a/tests/dataset_chat/test_retrieval.py
+++ b/tests/dataset_chat/test_retrieval.py
@@ -1,0 +1,89 @@
+import pytest
+
+from lib.datasets.models import Chunk
+from lib.datasets.retrieval import (
+    apply_document_diversity,
+    candidate_limit,
+    max_chunks_per_document,
+)
+
+
+def _chunk(chunk_id: str, document_name: str) -> Chunk:
+    return Chunk(
+        chunk_id=chunk_id,
+        document_name=document_name,
+        page_number=1,
+        last_modified=0.0,
+        text=f"text {chunk_id}",
+    )
+
+
+def test_candidate_limit_oversamples_by_default():
+    assert candidate_limit(25) == 100
+
+
+def test_candidate_limit_honours_configured_multiplier(monkeypatch):
+    monkeypatch.setenv("RETRIEVAL_CANDIDATE_MULTIPLIER", "2")
+
+    assert candidate_limit(25) == 50
+
+
+def test_candidate_limit_never_returns_fewer_than_requested(monkeypatch):
+    monkeypatch.setenv("RETRIEVAL_CANDIDATE_MULTIPLIER", "0.1")
+
+    assert candidate_limit(25) == 25
+
+
+def test_candidate_limit_ignores_invalid_configuration(monkeypatch):
+    monkeypatch.setenv("RETRIEVAL_CANDIDATE_MULTIPLIER", "not-a-number")
+
+    assert candidate_limit(25) == 100
+
+
+def test_candidate_limit_is_bounded():
+    assert candidate_limit(1000) == 400
+
+
+@pytest.mark.parametrize(
+    ("share", "expected"),
+    [("0.4", 10), ("0.2", 5), ("0", 25), ("1", 25)],
+)
+def test_max_chunks_per_document_follows_share(monkeypatch, share, expected):
+    monkeypatch.setenv("RETRIEVAL_MAX_DOCUMENT_SHARE", share)
+
+    assert max_chunks_per_document(25) == expected
+
+
+def test_max_chunks_per_document_is_at_least_one(monkeypatch):
+    monkeypatch.setenv("RETRIEVAL_MAX_DOCUMENT_SHARE", "0.1")
+
+    assert max_chunks_per_document(4) == 1
+
+
+def test_diversity_demotes_chunks_beyond_the_document_cap():
+    chunks = [_chunk(f"a{index}", "big.pdf") for index in range(4)]
+    chunks += [_chunk("b1", "small.pdf")]
+
+    selected = apply_document_diversity(chunks, limit=3, max_per_document=2)
+
+    assert [chunk.chunk_id for chunk in selected] == ["a0", "a1", "b1"]
+
+
+def test_diversity_backfills_rather_than_returning_fewer_chunks():
+    chunks = [_chunk(f"a{index}", "only.pdf") for index in range(5)]
+
+    selected = apply_document_diversity(chunks, limit=4, max_per_document=2)
+
+    assert [chunk.chunk_id for chunk in selected] == ["a0", "a1", "a2", "a3"]
+
+
+def test_diversity_preserves_order_when_cap_is_not_binding():
+    chunks = [_chunk("a1", "one.pdf"), _chunk("b1", "two.pdf")]
+
+    selected = apply_document_diversity(chunks, limit=5, max_per_document=5)
+
+    assert selected == chunks
+
+
+def test_diversity_returns_nothing_for_a_zero_limit():
+    assert apply_document_diversity([_chunk("a1", "one.pdf")], 0, 1) == []

--- a/tests/dataset_chat/test_sparse.py
+++ b/tests/dataset_chat/test_sparse.py
@@ -1,0 +1,78 @@
+from lib.datasets.sparse import (
+    encode_document,
+    encode_query,
+    token_id,
+    tokenize,
+)
+
+
+def test_tokenize_lowercases_and_drops_stopwords():
+    assert tokenize("The Company holds the Patent") == [
+        "company",
+        "holds",
+        "patent",
+    ]
+
+
+def test_tokenize_keeps_domain_terms_and_numbers():
+    tokens = tokenize("Art. 332 OR Inventionsabtretungserklärung")
+
+    assert "332" in tokens
+    assert "art" in tokens
+    assert "inventionsabtretungserklärung" in tokens
+
+
+def test_tokenize_drops_single_characters():
+    assert tokenize("a b IP") == ["ip"]
+
+
+def test_token_id_is_stable_and_fits_unsigned_32_bit():
+    first = token_id("patent")
+
+    assert first == token_id("patent")
+    assert 0 <= first < 2**32
+    assert first != token_id("patents")
+
+
+def test_encode_document_returns_sorted_unique_indices():
+    sparse = encode_document("patent assignment patent register")
+
+    assert sparse.indices == sorted(sparse.indices)
+    assert len(sparse.indices) == len(set(sparse.indices))
+    assert len(sparse.indices) == len(sparse.values)
+
+
+def test_encode_document_saturates_repeated_terms():
+    once = encode_document("patent")
+    many = encode_document("patent " * 10)
+    index = token_id("patent")
+
+    single_weight = once.values[once.indices.index(index)]
+    repeated_weight = many.values[many.indices.index(index)]
+
+    assert repeated_weight > single_weight
+    # BM25 saturation keeps term frequency from scaling linearly.
+    assert repeated_weight < single_weight * 10
+
+
+def test_encode_document_weights_rare_terms_higher_in_long_text():
+    short = encode_document("patent assignment")
+    long = encode_document("patent assignment " + "filler content " * 100)
+    index = token_id("patent")
+
+    assert (
+        long.values[long.indices.index(index)]
+        < short.values[short.indices.index(index)]
+    )
+
+
+def test_encode_query_uses_unit_weights_per_distinct_term():
+    sparse = encode_query("patent patent assignment")
+
+    assert sparse.indices == sorted({token_id("patent"), token_id("assignment")})
+    assert sparse.values == [1.0, 1.0]
+
+
+def test_encoding_empty_or_stopword_only_text_is_falsy():
+    assert not encode_document("")
+    assert not encode_query("the and of")

--- a/tests/dataset_maintenance/test_rebuild_index.py
+++ b/tests/dataset_maintenance/test_rebuild_index.py
@@ -1,0 +1,107 @@
+import pytest
+
+from lib.datasets.manifest import IngestionManifest
+from lib.storage import LocalStorage
+from skills.dataset_maintenance import maintenance
+
+
+class FakeAdmin:
+    def __init__(self, collections):
+        self.collections = collections
+        self.deleted = []
+
+    def list_collections(self):
+        return list(self.collections)
+
+    def delete_collection(self, collection):
+        self.deleted.append(collection)
+
+
+def _prepare(tmp_path, mocker, collections, documents):
+    storage = LocalStorage(tmp_path)
+    parsed_rel = "cache/datasets2md/example"
+    manifest = IngestionManifest(storage, parsed_rel)
+    manifest.documents = documents
+    manifest.indexed_dataset_revision = "revision-1"
+    manifest.save()
+
+    admin = FakeAdmin(collections)
+    mocker.patch.object(maintenance, "QdrantAdmin", return_value=admin)
+    mocker.patch.object(maintenance, "get_storage", return_value=storage)
+    mocker.patch.object(
+        maintenance,
+        "dataset_parsed_path",
+        return_value=parsed_rel,
+    )
+    return storage, parsed_rel, admin
+
+
+def test_rebuild_drops_the_collection_and_clears_index_checkpoints(
+    tmp_path,
+    mocker,
+):
+    storage, parsed_rel, admin = _prepare(
+        tmp_path,
+        mocker,
+        collections=["example-test-embedding-8b"],
+        documents={
+            "report.md": {
+                "source_sha256": "source",
+                "parsed_sha256": "parsed",
+                "parser_version": "docling",
+                "indexed_parsed_sha256": "parsed",
+                "indexed_chunker_version": "chunker",
+                "indexed_embedding_model": "model",
+            }
+        },
+    )
+
+    rebuild = maintenance.rebuild_dataset_index("Example")
+
+    assert rebuild.dataset == "example"
+    assert rebuild.collection_deleted is True
+    assert rebuild.documents_reset == 1
+    assert admin.deleted == ["example-test-embedding-8b"]
+
+    state = IngestionManifest.load(storage, parsed_rel).documents["report.md"]
+    # Parsing checkpoints survive so a rebuild re-embeds without re-parsing.
+    assert state["parsed_sha256"] == "parsed"
+    assert "indexed_parsed_sha256" not in state
+    assert "indexed_embedding_model" not in state
+
+
+def test_rebuild_reports_a_missing_collection_without_failing(tmp_path, mocker):
+    _storage, _parsed_rel, admin = _prepare(
+        tmp_path,
+        mocker,
+        collections=[],
+        documents={"report.md": {"indexed_parsed_sha256": "parsed"}},
+    )
+
+    rebuild = maintenance.rebuild_dataset_index("example")
+
+    assert rebuild.collection_deleted is False
+    assert admin.deleted == []
+    assert rebuild.documents_reset == 1
+
+
+def test_rebuild_ignores_documents_that_were_never_indexed(tmp_path, mocker):
+    storage, parsed_rel, _admin = _prepare(
+        tmp_path,
+        mocker,
+        collections=[],
+        documents={"report.md": {"parsed_sha256": "parsed"}},
+    )
+
+    rebuild = maintenance.rebuild_dataset_index("example")
+
+    assert rebuild.documents_reset == 0
+    assert (
+        IngestionManifest.load(storage, parsed_rel).indexed_dataset_revision
+        == "revision-1"
+    )
+
+
+def test_rebuild_requires_a_dataset():
+    with pytest.raises(ValueError, match="--dataset"):
+        maintenance.rebuild_dataset_index("")

--- a/tests/live/test_live_hybrid_search.py
+++ b/tests/live/test_live_hybrid_search.py
@@ -1,0 +1,110 @@
+"""Live check that BM25 fusion recovers exact-term hits dense search misses."""
+
+import pytest
+
+from lib.adapters.qdrant import QdrantAdapter, QdrantAdmin
+from lib.datasets.chunking import split_markdown
+from lib.datasets.indexing import replace_document
+from lib.datasets.sparse import encode_query
+
+DATASET = "sictic-live-hybrid-test"
+QUERY_VECTOR = [1.0, 0.0, 0.0, 0.0]
+EXACT_TERM = "Inventionsabtretungserklärung"
+
+DOCUMENTS = {
+    # Steered onto the query vector, so dense search ranks it first.
+    "share-purchase-agreement.pdf":
+        "The parties agree on the transfer of shares and closing. " * 5,
+    # Holds the exact term but is orthogonal to the query vector.
+    "patent-register.pdf":
+        f"IPI extract. {EXACT_TERM} signed under Art. 332 OR. " * 5,
+    "cap-table.xlsx":
+        "Founder holdings and option pool allocation. " * 5,
+}
+
+
+class _SteeredEmbeddings:
+    """Dense vectors chosen so dense-only search ranks the wrong document."""
+
+    model = "live-hybrid-test"
+
+    @staticmethod
+    def _vector(text: str) -> list[float]:
+        if "shares" in text:
+            return [1.0, 0.0, 0.0, 0.0]
+        if EXACT_TERM in text:
+            return [0.0, 1.0, 0.0, 0.0]
+        return [0.0, 0.0, 1.0, 0.0]
+
+    async def embed_many(self, texts):
+        return [self._vector(text) for text in texts]
+
+    def vector_size(self) -> int:
+        return 4
+
+
+@pytest.fixture
+def hybrid_collection():
+    try:
+        adapter = QdrantAdapter(DATASET, vector_size=4)
+    except Exception as error:
+        pytest.skip(f"Qdrant unavailable: {error}")
+    yield adapter
+    QdrantAdmin().delete_collection(adapter.collection_name)
+
+
+@pytest.mark.live
+@pytest.mark.asyncio
+async def test_live_bm25_branch_recovers_exact_term_matches(hybrid_collection):
+    assert hybrid_collection.sparse_enabled()
+
+    embeddings = _SteeredEmbeddings()
+    for name, text in DOCUMENTS.items():
+        await replace_document(
+            hybrid_collection,
+            embeddings,
+            name,
+            split_markdown(text, name, 1.0),
+            with_sparse=True,
+        )
+
+    dense = [
+        point.payload["document_name"]
+        for point in hybrid_collection.query(QUERY_VECTOR, limit=3)
+    ]
+    hybrid = [
+        point.payload["document_name"]
+        for point in hybrid_collection.query_hybrid(
+            QUERY_VECTOR,
+            encode_query(EXACT_TERM),
+            limit=3,
+            candidate_limit=20,
+        )
+    ]
+
+    assert dense[0] == "share-purchase-agreement.pdf"
+    assert dense.index("patent-register.pdf") == 2
+    assert hybrid[0] == "patent-register.pdf"
+
+
+@pytest.mark.live
+@pytest.mark.asyncio
+async def test_live_hybrid_falls_back_when_no_term_matches(hybrid_collection):
+    embeddings = _SteeredEmbeddings()
+    for name, text in DOCUMENTS.items():
+        await replace_document(
+            hybrid_collection,
+            embeddings,
+            name,
+            split_markdown(text, name, 1.0),
+            with_sparse=True,
+        )
+
+    results = hybrid_collection.query_hybrid(
+        QUERY_VECTOR,
+        encode_query("zzzznonexistentterm"),
+        limit=3,
+        candidate_limit=20,
+    )
+
+    assert [point.payload["document_name"] for point in results]

--- a/tests/utils/test_services_gateway.py
+++ b/tests/utils/test_services_gateway.py
@@ -51,9 +51,9 @@ def test_gateway_initialization_has_no_file_side_effect(clean_gateway):
     state = clean_gateway.snapshot()
 
     assert state == {
-        "version": 4,
-        "leases": {"docling": [], "embedding": [], "llm": []},
-        "requests": {"docling": [], "embedding": [], "llm": []},
+        "version": 5,
+        "leases": {"docling": [], "embedding": [], "llm": [], "rerank": []},
+        "requests": {"docling": [], "embedding": [], "llm": [], "rerank": []},
     }
 
 
@@ -424,13 +424,13 @@ async def test_gateway_logs_counts_when_request_arrives_and_starts(
 
     assert (
         "Gateway request received: LLM 0 running, 1 waiting | "
-        "embedding 0 running, 0 waiting | docling 0 running, 0 waiting | "
-        "models 0/2 loaded"
+        "embedding 0 running, 0 waiting | rerank 0 running, 0 waiting | "
+        "docling 0 running, 0 waiting | models 0/2 loaded"
     ) in caplog.text
     assert (
         "Gateway job started: LLM 1 running, 0 waiting | "
-        "embedding 0 running, 0 waiting | docling 0 running, 0 waiting | "
-        "models 1/2 loaded"
+        "embedding 0 running, 0 waiting | rerank 0 running, 0 waiting | "
+        "docling 0 running, 0 waiting | models 1/2 loaded"
     ) in caplog.text
 
 


### PR DESCRIPTION
Improvement of RAG retrieval quality — in three parts: hybrid dense+sparse search, a reranker stage, and retrieval diversity. 

### How search works now
A query used to be embedded once and matched against dense vectors. It now goes through three stages:

Hybrid retrieval. The question is both embedded and tokenized into BM25 keyword terms. Both run against the same Qdrant collection and Qdrant fuses the two rankings server-side with reciprocal rank fusion. The dense side handles paraphrases; the BM25 side catches exact strings that a small local embedding model blurs — `Inventionsabtretungserklärung`, `Art. 332 OR`, a specific patent number.

Reranking. Retrieval pulls 4× the requested chunks, and an optional cross-encoder rescores them by reading the question and chunk together. Off unless RERANK_MODEL is set.

Diversification. A per-document cap stops one 200-page shareholder agreement from filling the entire context and hiding the cap table. Overflow chunks are demoted rather than dropped, so you always get back the number of chunks you asked for.

### Three decisions made deliberately
BM25 needs no new dependency or service. Qdrant computes the inverse document frequency itself via its IDF modifier, so the code only stores stateless term frequencies per chunk. No fastembed, no extra model, nothing new running on the LAN — which mattered given your local-network requirement.

Reranking is opt-in and fails soft. Bundling a cross-encoder would force a HuggingFace download and break air-gapped installs, so it activates only via RERANK_MODEL and silently keeps the fusion order on any failure. The README documents pointing it at a self-hosted Infinity server so documents never leave the machine.

No automatic migration of existing indexes. I probed this before designing: Qdrant refuses to add a sparse vector to an existing collection (`Not existing vector name error: bm25`), so hybrid requires recreating the collection and re-embedding. Rather than run a destructive migration behind your back on a large data room, pre-existing collections keep working exactly as today in dense-only mode and upgrade when you choose:

`python -m skills.dataset_maintenance rebuild-index --dataset avientus`

That keeps parsed Markdown, so a rebuild re-embeds but never re-runs Docling.

### Code
Three new modules: lib/datasets/sparse.py (BM25 tokenizer and encoder), lib/datasets/retrieval.py (candidate sizing and the diversity cap), lib/datasets/reranking.py (cross-encoder stage). The Qdrant adapter gained sparse vector storage and a query_hybrid method; search.py was rewired into the retrieve→rerank→diversify pipeline; the ingestion manifest tracks a sparse-index version so datasets self-heal into hybrid after a rebuild without re-embedding datasets that don't need it. Config went into .env-template, model_config.py, and the services gateway (a rerank concurrency slot), plus README and SKILL.md documentation.

### Verification
I didn't just assert the BM25 branch helps — I proved it against your live Qdrant. I indexed three documents with dense vectors deliberately steered so the document containing the exact term ranked last on dense similarity. Hybrid search pulled it to first, and a query matching no terms degraded cleanly back to dense results. That check is preserved in the repo as a live-marked test.

I also confirmed your real exnunc collection correctly reports itself as pre-hybrid and falls back without error.

Full suite is green at 502 passed, with 74 new tests plus the 2 live ones (SICTIC_RUN_LIVE_SMOKE=1 to run those).

### One consequence to know
Rebuilding a dataset changes its index revision, which regenerates that dataset's cached insights. That's intentional — retrieval genuinely changed — but it's real compute on a large data room, so plan the first rebuild for when the machine is free.


_This PR code and PR text were written by Claude Code._