### PR TITLE
Better Ingestion of Tables

### DIFF
--- a/docs/installation-and-operations.md
+++ b/docs/installation-and-operations.md
@@ -199,6 +199,37 @@ document, such as a 200-page shareholder agreement, from filling the whole
 context and hiding the cap table. Chunks above the cap are demoted rather than
 dropped, so the requested number of chunks is still returned.
 
+### Tables and spreadsheets
+
+A table that does not fit in one chunk loses its header on the first cut, and
+every chunk after that is a block of cells no model can attribute to a column.
+Chunking is therefore table-aware. A table larger than one chunk is split on row
+boundaries, never mid-row, and every chunk repeats the header. Because each
+chunk re-spends part of its budget on that header, tables use a larger chunk
+size than prose. This applies wherever tables come from: worksheets, CSV
+exports, and tables embedded in PDFs and Word documents.
+
+Tables small enough to survive intact are left alone, inside the prose that
+surrounds them, since the sentence before a short table is usually what explains
+it.
+
+Where a table carries a GitHub-style separator row, that row identifies the
+header and is trusted. Otherwise the header is inferred, because workbooks
+routinely stack title and grouping rows above the row that actually names the
+columns. A header is recognised by how much more label-like it is than the rows
+beneath it, not by an absolute score: a sheet that is simply a column of labelled
+values has no header at all, and must not have one of its value rows promoted
+into every chunk.
+
+Workbooks are not converted by Docling. They are read directly with `openpyxl`
+(or `xlrd` for legacy `.xls`), which keeps hidden rows, hidden columns, hidden
+sheets and formula error cells out of the index, and writes one Markdown table
+per visible worksheet. Values are rendered the way a reader would write them, so
+a share price becomes `15.15` rather than `15.151515151515152`, a
+percent-formatted cell becomes `24.69%` rather than `0.24685415429152754`, and a
+date becomes `2026-01-19`. Chunks from a workbook are cited by sheet name
+instead of a page number.
+
 ### Upgrading an existing index
 
 Qdrant cannot add sparse vectors to a collection that was created without them,

--- a/lib/adapters/docling/spreadsheets.py
+++ b/lib/adapters/docling/spreadsheets.py
@@ -1,13 +1,21 @@
 from __future__ import annotations
 
+import datetime
+
+from lib.datasets.spreadsheet_markdown import SPREADSHEET_MARKDOWN_MARKER
 from lib.logger import get_logger
 
 logger = get_logger(__name__)
 
 SPREADSHEET_EXTENSIONS = (".xls", ".xlsx", ".xlsm")
-SPREADSHEET_MARKDOWN_MARKER = (
-    "<!-- sictic-spreadsheet: compact-values-v2 -->"
-)
+
+__all__ = [
+    "SPREADSHEET_EXTENSIONS",
+    "SPREADSHEET_MARKDOWN_MARKER",
+    "convert_spreadsheet",
+    "format_cell_value",
+    "is_spreadsheet_filename",
+]
 
 
 def is_spreadsheet_filename(filename: str) -> bool:
@@ -53,11 +61,9 @@ def convert_openpyxl(filepath: str) -> str:
             for (row, col), cell in values_ws._cells.items():
                 if is_hidden(row, col) or cell.data_type == "e":
                     continue
-                value = cell.value
-                text = (
-                    ""
-                    if value is None
-                    else str(value).replace("\n", " ").strip()
+                text = format_cell_value(
+                    cell.value,
+                    getattr(cell, "number_format", ""),
                 )
                 if text:
                     row_cells.setdefault(row, {})[col] = text
@@ -154,6 +160,53 @@ def escape_markdown_cell(value: str) -> str:
     return value.replace("|", "\\|")
 
 
+def format_cell_value(value, number_format: str = "") -> str:
+    """Render a cell as text a reader (and an embedding model) can use."""
+    if value is None:
+        return ""
+    if isinstance(value, bool):
+        return "TRUE" if value else "FALSE"
+    if isinstance(value, (datetime.datetime, datetime.date, datetime.time)):
+        return format_temporal(value)
+    if isinstance(value, int):
+        return str(value)
+    if isinstance(value, float):
+        return format_float(value, number_format)
+    return str(value).replace("\n", " ").strip()
+
+
+def format_temporal(value) -> str:
+    if isinstance(value, datetime.datetime):
+        if (value.hour, value.minute, value.second) == (0, 0, 0):
+            return value.date().isoformat()
+        return value.isoformat(sep=" ", timespec="minutes")
+    if isinstance(value, datetime.time):
+        return value.isoformat(timespec="minutes")
+    return value.isoformat()
+
+
+def format_float(value: float, number_format: str = "") -> str:
+    if value != value or value in (float("inf"), float("-inf")):
+        return str(value)
+    if "%" in (number_format or ""):
+        return f"{format_magnitude(value * 100)}%"
+    return format_magnitude(value)
+
+
+def format_magnitude(value: float) -> str:
+    """Drop float noise: spreadsheet ratios carry far more digits than meaning."""
+    if value == int(value):
+        return str(int(value))
+    magnitude = abs(value)
+    if magnitude >= 1:
+        text = f"{value:.2f}"
+    elif magnitude >= 1e-4:
+        text = f"{value:.4f}"
+    else:
+        return f"{value:.4g}"
+    return text.rstrip("0").rstrip(".")
+
+
 def render_spreadsheet_markdown(sections: list[str]) -> str:
     body = "\n".join(sections).strip()
     if not body:
@@ -162,8 +215,6 @@ def render_spreadsheet_markdown(sections: list[str]) -> str:
 
 
 def xls_cell_text(value) -> str:
-    if value in (None, ""):
+    if value is None or value == "":
         return ""
-    if isinstance(value, float) and value.is_integer():
-        value = int(value)
-    return str(value).replace("\n", " ").strip()
+    return format_cell_value(value)

--- a/lib/datasets/chunking.py
+++ b/lib/datasets/chunking.py
@@ -2,33 +2,186 @@ from __future__ import annotations
 
 import hashlib
 import uuid
+from collections.abc import Iterator
 
 from langchain_text_splitters import MarkdownTextSplitter
 
+from lib.datasets.markdown_tables import (
+    TABLE_SEGMENT,
+    TableBlock,
+    iter_segments,
+    parse_table,
+)
 from lib.datasets.models import Chunk
-from lib.datasets.page_markers import split_text_by_pages
+from lib.datasets.page_markers import UNKNOWN_PAGE, split_text_by_pages
+from lib.datasets.spreadsheet_markdown import (
+    is_spreadsheet_markdown,
+    split_sheets,
+)
 from lib.datasets.text_normalization import normalize_extracted_text
+
+CHUNK_SIZE = 1000
+CHUNK_OVERLAP = 100
+# Table rows are denser than prose and every chunk re-spends part of its
+# budget on the repeated header, so tables get a larger window.
+TABLE_CHUNK_SIZE = 2000
+MAX_HEADER_CHARS = 400
+MIN_BODY_CHARS = 300
+
+PROSE_SPLITTER = MarkdownTextSplitter(
+    chunk_size=CHUNK_SIZE,
+    chunk_overlap=CHUNK_OVERLAP,
+)
 
 
 def split_markdown(text: str, filename: str, mod_time: float) -> list[Chunk]:
     text = normalize_extracted_text(text)
-    splitter = MarkdownTextSplitter(chunk_size=1000, chunk_overlap=100)
+    if is_spreadsheet_markdown(text):
+        return split_spreadsheet(text, filename, mod_time)
+
     chunks: list[Chunk] = []
     for page_number, section_text in split_text_by_pages(text):
         if not section_text.strip():
             continue
-        for doc in splitter.create_documents([section_text]):
-            content = doc.page_content
-            chunk_hash = hashlib.md5(
-                f"{filename}_{content}".encode("utf-8")
-            ).hexdigest()
-            chunks.append(
-                Chunk(
-                    chunk_id=str(uuid.UUID(hex=chunk_hash)),
-                    document_name=filename,
-                    page_number=page_number,
-                    last_modified=mod_time,
-                    text=content,
+        chunks.extend(
+            split_section(section_text, filename, page_number, mod_time)
+        )
+    return chunks
+
+
+def split_section(
+    text: str,
+    filename: str,
+    page_number: int | str,
+    mod_time: float,
+) -> list[Chunk]:
+    """Chunk one page, keeping large tables readable.
+
+    A table too big to fit in a chunk loses its header on the first cut, which
+    leaves every later chunk as unlabelled cells. Such tables are chunked on
+    row boundaries with their header repeated; everything else, including
+    tables small enough to survive intact, stays with its surrounding prose.
+    """
+    chunks: list[Chunk] = []
+    for kind, segment in iter_segments(text, TABLE_CHUNK_SIZE):
+        if kind == TABLE_SEGMENT:
+            table = parse_table(segment.splitlines())
+            chunks.extend(
+                chunks_for_table(
+                    table, "", filename, page_number, mod_time
                 )
             )
+            continue
+        for doc in PROSE_SPLITTER.create_documents([segment]):
+            chunks.append(
+                build_chunk(doc.page_content, filename, page_number, mod_time)
+            )
     return chunks
+
+
+def split_spreadsheet(
+    text: str,
+    filename: str,
+    mod_time: float,
+) -> list[Chunk]:
+    """Chunk a workbook so every chunk keeps the labels its numbers need."""
+    chunks: list[Chunk] = []
+    for sheet in split_sheets(text):
+        table = TableBlock(header=sheet.header, separator="", rows=sheet.rows)
+        title = f"## {sheet.name}" if sheet.name else ""
+        chunks.extend(
+            chunks_for_table(
+                table,
+                title,
+                filename,
+                sheet.name or UNKNOWN_PAGE,
+                mod_time,
+            )
+        )
+    return chunks
+
+
+def chunks_for_table(
+    table: TableBlock,
+    title: str,
+    filename: str,
+    page_number: int | str,
+    mod_time: float,
+) -> list[Chunk]:
+    prefix = table_prefix(table, title)
+    budget = max(TABLE_CHUNK_SIZE - len(prefix), MIN_BODY_CHARS)
+    bodies = list(pack_rows(table.rows, budget))
+    if not bodies:
+        if not prefix:
+            return []
+        return [build_chunk(prefix, filename, page_number, mod_time)]
+    return [
+        build_chunk(
+            f"{prefix}\n{body}" if prefix else body,
+            filename,
+            page_number,
+            mod_time,
+        )
+        for body in bodies
+    ]
+
+
+def table_prefix(table: TableBlock, title: str) -> str:
+    lines = []
+    if title:
+        lines.append(title)
+    if table.header:
+        header = truncate_row(table.header, MAX_HEADER_CHARS)
+        lines.append(header)
+        # A truncated header no longer matches its separator's column count.
+        if table.separator and header == table.header:
+            lines.append(table.separator)
+    return "\n".join(lines)
+
+
+def truncate_row(row: str, limit: int) -> str:
+    if len(row) <= limit:
+        return row
+    return row[:limit].rstrip() + " ..."
+
+
+def pack_rows(rows: list[str], budget: int) -> Iterator[str]:
+    """Group whole rows into bodies that fit the budget."""
+    batch: list[str] = []
+    length = 0
+    for row in rows:
+        for piece in fit_row(row, budget):
+            addition = len(piece) + (1 if batch else 0)
+            if batch and length + addition > budget:
+                yield "\n".join(batch)
+                batch = []
+                length = 0
+                addition = len(piece)
+            batch.append(piece)
+            length += addition
+    if batch:
+        yield "\n".join(batch)
+
+
+def fit_row(row: str, budget: int) -> list[str]:
+    if len(row) <= budget:
+        return [row]
+    return [row[start:start + budget] for start in range(0, len(row), budget)]
+
+
+def build_chunk(
+    content: str,
+    filename: str,
+    page_number: int | str,
+    mod_time: float,
+) -> Chunk:
+    chunk_hash = hashlib.md5(
+        f"{filename}_{content}".encode("utf-8")
+    ).hexdigest()
+    return Chunk(
+        chunk_id=str(uuid.UUID(hex=chunk_hash)),
+        document_name=filename,
+        page_number=page_number,
+        last_modified=mod_time,
+        text=content,
+    )

--- a/lib/datasets/manifest.py
+++ b/lib/datasets/manifest.py
@@ -16,7 +16,7 @@ logger = get_logger(__name__)
 MANIFEST_FILENAME = ".ingestion-manifest.json"
 MANIFEST_VERSION = 1
 PARSER_VERSION = "docling-page-markers-v1"
-CHUNKER_VERSION = "markdown-1000-100-v1"
+CHUNKER_VERSION = "markdown-1000-100-table-aware-v2"
 
 
 def content_hash(content: bytes | str) -> str:

--- a/lib/datasets/markdown_tables.py
+++ b/lib/datasets/markdown_tables.py
@@ -1,0 +1,178 @@
+"""Structure of Markdown tables, wherever they come from.
+
+Shared by spreadsheet conversion, CSV output and tables embedded in parsed
+PDFs and Word documents. Kept free of heavy imports so the chunker can use it.
+"""
+
+from __future__ import annotations
+
+import re
+import statistics
+from collections.abc import Iterator
+from dataclasses import dataclass
+
+TABLE_LINE_RE = re.compile(r"^\|")
+SEPARATOR_CELL_RE = re.compile(r"^:?-+:?$")
+CELL_SPLIT_RE = re.compile(r"(?<!\\)\|")
+
+HEADER_SCAN_ROWS = 6
+MIN_HEADER_LABELS = 2
+HEADER_MARGIN = 2
+
+PROSE_SEGMENT = "prose"
+TABLE_SEGMENT = "table"
+
+
+@dataclass(frozen=True)
+class TableBlock:
+    """A table split into the lines that label it and the lines that fill it."""
+
+    header: str
+    separator: str
+    rows: list[str]
+
+
+def is_table_line(line: str) -> bool:
+    return bool(TABLE_LINE_RE.match(line.strip()))
+
+
+def split_cells(row: str) -> list[str]:
+    stripped = row.strip()
+    if not stripped.startswith("|"):
+        return []
+    return [cell.strip() for cell in CELL_SPLIT_RE.split(stripped)[1:-1]]
+
+
+def is_separator_row(row: str) -> bool:
+    cells = split_cells(row)
+    return bool(cells) and all(
+        SEPARATOR_CELL_RE.match(cell) for cell in cells if cell
+    )
+
+
+def looks_numeric(cell: str) -> bool:
+    candidate = cell.replace("'", "").replace(",", "").replace("%", "")
+    for symbol in ("CHF", "EUR", "USD", "$", "€"):
+        candidate = candidate.replace(symbol, "")
+    candidate = candidate.strip().lstrip("(").rstrip(")")
+    if not candidate:
+        return False
+    try:
+        float(candidate)
+    except ValueError:
+        return False
+    return True
+
+
+def label_count(row: str) -> int:
+    return sum(
+        1 for cell in split_cells(row) if cell and not looks_numeric(cell)
+    )
+
+
+def header_score(row: str) -> int:
+    """Score a row on how much it names columns rather than holding values.
+
+    Numbers count against a row instead of disqualifying it, because genuine
+    headers do sometimes contain them, as in a row of year columns.
+    """
+    score = 0
+    for cell in split_cells(row):
+        if not cell:
+            continue
+        score += -1 if looks_numeric(cell) else 1
+    return score
+
+
+def select_header(rows: list[str]) -> int:
+    """Return the index of the row that names the columns, or -1 if none does.
+
+    Real workbooks stack title and grouping rows above the row that actually
+    names the columns, so the first row is often not the useful one. A header
+    is recognised by standing out from the rows beneath it rather than by any
+    absolute score, since a sheet of labelled values has no header at all and
+    must not have one of its value rows promoted into every chunk.
+    """
+    window = rows[:HEADER_SCAN_ROWS]
+    if not window:
+        return -1
+    best_index = max(
+        range(len(window)),
+        key=lambda index: header_score(window[index]),
+    )
+    if label_count(rows[best_index]) < MIN_HEADER_LABELS:
+        return -1
+    body = rows[HEADER_SCAN_ROWS:] or rows[best_index + 1:]
+    if not body:
+        return best_index
+    baseline = statistics.median(header_score(row) for row in body)
+    if header_score(rows[best_index]) < baseline + HEADER_MARGIN:
+        return -1
+    return best_index
+
+
+def parse_table(rows: list[str]) -> TableBlock:
+    """Split table lines into header, separator and body.
+
+    A GitHub-style separator row states which line is the header, so it is
+    trusted when present; otherwise the header has to be inferred.
+    """
+    for index, row in enumerate(rows[:HEADER_SCAN_ROWS]):
+        if not is_separator_row(row):
+            continue
+        if index == 0:
+            return TableBlock(header="", separator=row, rows=rows[1:])
+        return TableBlock(
+            header=rows[index - 1],
+            separator=row,
+            rows=rows[:index - 1] + rows[index + 1:],
+        )
+
+    header_index = select_header(rows)
+    if header_index < 0:
+        return TableBlock(header="", separator="", rows=list(rows))
+    return TableBlock(
+        header=rows[header_index],
+        separator="",
+        rows=rows[:header_index] + rows[header_index + 1:],
+    )
+
+
+def iter_segments(
+    text: str,
+    min_table_chars: int,
+) -> Iterator[tuple[str, str]]:
+    """Split Markdown into prose and large-table segments.
+
+    Only tables too big to survive chunking intact are separated out. Smaller
+    ones stay with the prose around them, which is usually what explains them.
+    """
+    prose: list[str] = []
+    table: list[str] = []
+
+    def flush_prose() -> Iterator[tuple[str, str]]:
+        body = "\n".join(prose).strip()
+        prose.clear()
+        if body:
+            yield (PROSE_SEGMENT, body)
+
+    def flush_table() -> Iterator[tuple[str, str]]:
+        body = "\n".join(table)
+        table.clear()
+        if not body.strip():
+            return
+        if len(body) < min_table_chars:
+            prose.append(body)
+            return
+        yield from flush_prose()
+        yield (TABLE_SEGMENT, body)
+
+    for line in text.splitlines():
+        if is_table_line(line):
+            table.append(line.strip())
+            continue
+        yield from flush_table()
+        prose.append(line)
+
+    yield from flush_table()
+    yield from flush_prose()

--- a/lib/datasets/spreadsheet_markdown.py
+++ b/lib/datasets/spreadsheet_markdown.py
@@ -1,0 +1,62 @@
+"""Shared structure of spreadsheet-derived Markdown.
+
+Kept free of heavy imports so both the Docling adapter and the chunker can
+use it without pulling in document conversion dependencies.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from lib.datasets.markdown_tables import select_header
+
+SPREADSHEET_MARKDOWN_MARKER = "<!-- sictic-spreadsheet: compact-values-v3 -->"
+SPREADSHEET_MARKER_RE = re.compile(r"<!--\s*sictic-spreadsheet:[^>]*-->")
+SHEET_HEADING_RE = re.compile(r"^##\s+(.*)$")
+
+
+@dataclass(frozen=True)
+class SheetSection:
+    """One worksheet: its title, its header row, and its remaining rows."""
+
+    name: str
+    header: str
+    rows: list[str]
+
+
+def is_spreadsheet_markdown(text: str) -> bool:
+    return bool(SPREADSHEET_MARKER_RE.match(text.lstrip()))
+
+
+def split_sheets(text: str) -> list[SheetSection]:
+    """Split spreadsheet Markdown into per-worksheet sections."""
+    body = SPREADSHEET_MARKER_RE.sub("", text, count=1)
+    sections: list[SheetSection] = []
+    name = ""
+    rows: list[str] = []
+
+    def flush() -> None:
+        if not rows:
+            return
+        header_index = select_header(rows)
+        header = rows[header_index] if header_index >= 0 else ""
+        remaining = [
+            row for index, row in enumerate(rows) if index != header_index
+        ]
+        sections.append(SheetSection(name=name, header=header, rows=remaining))
+
+    for line in body.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        heading = SHEET_HEADING_RE.match(stripped)
+        if heading:
+            flush()
+            name = heading.group(1).strip()
+            rows = []
+            continue
+        rows.append(stripped)
+
+    flush()
+    return sections

--- a/tests/dataset_chat/test_ingestion_spreadsheets.py
+++ b/tests/dataset_chat/test_ingestion_spreadsheets.py
@@ -24,6 +24,17 @@ def test_previous_compact_spreadsheet_cache_is_stale():
     assert spreadsheet_cache_is_current(storage, "model.xlsx.md", "model.xlsx") is False
 
 
+def test_unrounded_compact_spreadsheet_cache_is_stale():
+    storage = SimpleNamespace(
+        exists=lambda _path: True,
+        read_text=lambda _path: (
+            "<!-- sictic-spreadsheet: compact-values-v2 -->\n\n## Sheet\n"
+        ),
+    )
+
+    assert spreadsheet_cache_is_current(storage, "model.xlsx.md", "model.xlsx") is False
+
+
 def test_versioned_spreadsheet_cache_is_current():
     storage = SimpleNamespace(
         exists=lambda _path: True,

--- a/tests/dataset_chat/test_spreadsheet_chunking.py
+++ b/tests/dataset_chat/test_spreadsheet_chunking.py
@@ -1,0 +1,169 @@
+import datetime
+
+import pytest
+
+from lib.adapters.docling.spreadsheets import format_cell_value
+from lib.datasets.chunking import split_markdown
+from lib.datasets.markdown_tables import select_header
+from lib.datasets.spreadsheet_markdown import (
+    SPREADSHEET_MARKDOWN_MARKER,
+    is_spreadsheet_markdown,
+    split_sheets,
+)
+
+HEADER = "| Shareholder | Category | Shares | Ownership |"
+
+
+def sheet_markdown(*sheets: tuple[str, list[str]]) -> str:
+    body = "\n\n".join(
+        "\n".join([f"## {name}", *rows]) for name, rows in sheets
+    )
+    return f"{SPREADSHEET_MARKDOWN_MARKER}\n\n{body}\n"
+
+
+def investor_rows(count: int) -> list[str]:
+    return [
+        f"| Investor {index} | BA | {1000 + index} | 0.0{index:02d} |"
+        for index in range(count)
+    ]
+
+
+def test_select_header_prefers_labelled_row_over_title_rows():
+    rows = [
+        "|  | Round Jan 25 |  |  |",
+        "|  |  | valuation | shares |",
+        "| Category | Cash-in | Common Shares | Total Shares |",
+        "| Founders |  | 86380 | 86380 |",
+    ]
+
+    assert select_header(rows) == 2
+
+
+def test_select_header_reports_none_when_no_row_carries_labels():
+    assert select_header(["| 1 | 2 | 3 |", "| 4 | 5 | 6 |"]) == -1
+
+
+def test_select_header_rejects_a_value_row_that_happens_to_have_labels():
+    rows = [
+        "|  | Pre-money valuation | CHF | 3500000 |",
+        "|  | Post-money valuation | CHF | 4345000 |",
+    ]
+
+    assert select_header(rows) == -1
+
+
+def test_select_header_keeps_a_genuine_header_of_year_columns():
+    rows = [
+        "| Position | 2023 | 2024 | 2025 | 2026 | share |",
+        "| Revenue | 100 | 200 | 300 | 400 | 0.12 |",
+    ]
+
+    assert select_header(rows) == 0
+
+
+def test_split_sheets_separates_header_from_body():
+    text = sheet_markdown(("Cap Table", [HEADER, *investor_rows(3)]))
+
+    sections = split_sheets(text)
+
+    assert len(sections) == 1
+    assert sections[0].name == "Cap Table"
+    assert sections[0].header == HEADER
+    assert len(sections[0].rows) == 3
+    assert HEADER not in sections[0].rows
+
+
+def test_every_chunk_repeats_the_sheet_title_and_header():
+    text = sheet_markdown(("Cap Table", [HEADER, *investor_rows(200)]))
+
+    chunks = split_markdown(text, "cap.xlsx", 0.0)
+
+    assert len(chunks) > 1
+    for chunk in chunks:
+        assert chunk.text.startswith(f"## Cap Table\n{HEADER}\n")
+        assert chunk.text.count(HEADER) == 1
+
+
+def test_chunks_are_attributed_to_their_worksheet():
+    text = sheet_markdown(
+        ("Cap Table", [HEADER, *investor_rows(60)]),
+        ("Runway", ["| Month | Burn |", "| Jan | -64000 |"]),
+    )
+
+    chunks = split_markdown(text, "model.xlsx", 0.0)
+
+    assert {chunk.page_number for chunk in chunks} == {"Cap Table", "Runway"}
+    runway = [chunk for chunk in chunks if chunk.page_number == "Runway"]
+    assert len(runway) == 1
+    assert "| Jan | -64000 |" in runway[0].text
+
+
+def test_rows_are_never_split_across_chunks():
+    text = sheet_markdown(("Cap Table", [HEADER, *investor_rows(200)]))
+
+    chunks = split_markdown(text, "cap.xlsx", 0.0)
+
+    emitted = [
+        line
+        for chunk in chunks
+        for line in chunk.text.splitlines()
+        if line.startswith("| Investor ")
+    ]
+    assert emitted == investor_rows(200)
+
+
+def test_oversized_row_is_split_but_keeps_its_header():
+    giant = "| Notes | " + ("commentary " * 900) + "|"
+    text = sheet_markdown(("Cap Table", [HEADER, giant]))
+
+    chunks = split_markdown(text, "cap.xlsx", 0.0)
+
+    assert len(chunks) > 1
+    assert all(HEADER in chunk.text for chunk in chunks)
+
+
+def test_sheet_with_only_a_header_still_produces_a_chunk():
+    text = sheet_markdown(("Empty", [HEADER]))
+
+    chunks = split_markdown(text, "cap.xlsx", 0.0)
+
+    assert len(chunks) == 1
+    assert chunks[0].text == f"## Empty\n{HEADER}"
+
+
+def test_markdown_without_the_marker_uses_the_prose_splitter():
+    text = "## Cap Table\n" + HEADER + "\n" + "\n".join(investor_rows(200))
+
+    chunks = split_markdown(text, "cap.md", 0.0)
+
+    assert any(HEADER not in chunk.text for chunk in chunks)
+
+
+def test_previously_parsed_spreadsheets_are_still_recognised():
+    legacy = "<!-- sictic-spreadsheet: compact-values-v1 -->\n\n## S\n| a | b |"
+
+    assert is_spreadsheet_markdown(legacy)
+
+
+@pytest.mark.parametrize(
+    "value,number_format,expected",
+    [
+        (None, "", ""),
+        (72310, "", "72310"),
+        (1.0, "", "1"),
+        (15.151515151515152, "", "15.15"),
+        (8136.825000000001, "", "8136.83"),
+        (0.24685415429152754, "", "0.2469"),
+        (0.002, "", "0.002"),
+        (0.0000123, "", "1.23e-05"),
+        (0.24685415429152754, "0.00%", "24.69%"),
+        (True, "", "TRUE"),
+        (False, "", "FALSE"),
+        (datetime.datetime(2026, 1, 19), "", "2026-01-19"),
+        (datetime.datetime(2026, 1, 19, 14, 30), "", "2026-01-19 14:30"),
+        (datetime.date(2026, 3, 16), "", "2026-03-16"),
+        ("  spaced  text  ", "", "spaced  text"),
+    ],
+)
+def test_format_cell_value(value, number_format, expected):
+    assert format_cell_value(value, number_format) == expected

--- a/tests/dataset_chat/test_table_chunking.py
+++ b/tests/dataset_chat/test_table_chunking.py
@@ -1,0 +1,113 @@
+from lib.datasets.chunking import TABLE_CHUNK_SIZE, split_markdown
+from lib.datasets.markdown_tables import (
+    PROSE_SEGMENT,
+    TABLE_SEGMENT,
+    iter_segments,
+    is_separator_row,
+    parse_table,
+)
+from lib.datasets.page_markers import format_page_marker
+
+HEADER = "| Ortschaftsname | PLZ4 | Gemeindename | Kanton |"
+SEPARATOR = "|----------------|------|--------------|--------|"
+
+
+def place_rows(count: int) -> list[str]:
+    return [
+        f"| Lausanne {index} | {1000 + index} | Lausanne | VD |"
+        for index in range(count)
+    ]
+
+
+def csv_markdown(count: int) -> str:
+    return "\n".join([HEADER, SEPARATOR, *place_rows(count)])
+
+
+def test_is_separator_row():
+    assert is_separator_row(SEPARATOR)
+    assert is_separator_row("| :--- | ---: |")
+    assert not is_separator_row(HEADER)
+
+
+def test_parse_table_trusts_the_separator_row():
+    table = parse_table([HEADER, SEPARATOR, *place_rows(3)])
+
+    assert table.header == HEADER
+    assert table.separator == SEPARATOR
+    assert table.rows == place_rows(3)
+
+
+def test_parse_table_infers_a_header_without_a_separator():
+    table = parse_table([HEADER, *place_rows(8)])
+
+    assert table.header == HEADER
+    assert table.separator == ""
+    assert HEADER not in table.rows
+
+
+def test_small_tables_stay_with_their_prose():
+    text = (
+        "The round is summarised below.\n\n"
+        f"{HEADER}\n{SEPARATOR}\n" + "\n".join(place_rows(2))
+    )
+
+    segments = list(iter_segments(text, TABLE_CHUNK_SIZE))
+
+    assert [kind for kind, _body in segments] == [PROSE_SEGMENT]
+    assert HEADER in segments[0][1]
+
+
+def test_large_tables_are_separated_from_prose():
+    text = "Intro paragraph.\n\n" + csv_markdown(200) + "\n\nClosing note."
+
+    segments = list(iter_segments(text, TABLE_CHUNK_SIZE))
+
+    assert [kind for kind, _body in segments] == [
+        PROSE_SEGMENT,
+        TABLE_SEGMENT,
+        PROSE_SEGMENT,
+    ]
+    assert segments[0][1] == "Intro paragraph."
+    assert segments[2][1] == "Closing note."
+
+
+def test_every_chunk_of_a_large_table_repeats_the_header():
+    chunks = split_markdown(csv_markdown(400), "places.csv", 0.0)
+
+    assert len(chunks) > 1
+    for chunk in chunks:
+        assert chunk.text.startswith(f"{HEADER}\n{SEPARATOR}\n")
+        assert chunk.text.count(HEADER) == 1
+
+
+def test_large_table_rows_survive_intact():
+    chunks = split_markdown(csv_markdown(400), "places.csv", 0.0)
+
+    emitted = [
+        line
+        for chunk in chunks
+        for line in chunk.text.splitlines()
+        if line.startswith("| Lausanne ")
+    ]
+    assert emitted == place_rows(400)
+
+
+def test_table_chunks_keep_the_page_they_came_from():
+    text = (
+        f"{format_page_marker(4)}\n\nIntro paragraph.\n\n" + csv_markdown(200)
+    )
+
+    chunks = split_markdown(text, "report.pdf", 0.0)
+
+    assert chunks
+    assert all(chunk.page_number == 4 for chunk in chunks)
+
+
+def test_prose_only_documents_are_unaffected():
+    text = "This is a test document. " * 100
+
+    chunks = split_markdown(text, "notes.md", 0.0)
+
+    assert chunks
+    assert all(chunk.page_number == "n/a" for chunk in chunks)
+    assert "This is a test document." in chunks[0].text


### PR DESCRIPTION
## Table-aware ingestion for spreadsheets, CSVs and embedded tables

Large tables were being indexed in a form no model could use. A table that doesn't fit in one chunk lost its header on the first cut, so every chunk after that was a wall of unlabelled cells, and slicing a spreadsheet every 1000 characters produced enormous numbers of them. In a test data room, spreadsheets and CSVs accounted for roughly 90% of all chunks while the pitch deck, shareholders' agreement and factsheet combined accounted for about 10%.

### The two problems

**Numbers without meaning.** The header row was emitted once per sheet, so only the first chunk kept the column names. Measured over the test data room, 20% of chunks from a cap-table workbook and 0% of chunks from a sales-pipeline workbook contained even the sheet title. A typical chunk looked like this, with thirty numbers and nothing saying which is the committed cash investment, which is the share count, and which is the ownership fraction:

```
|  | Conversion |  | 0 | 0 | 0 | 0 | 0 |  | 50000 | 8136.825000000001 | 8136 |  | 8136 | 41864 | ...
```

**Chunk explosion.** Not caused by blank cells — the converter already skips those. It was the flat character splitter, which had no notion of table structure. A single sales-pipeline workbook produced 483 chunks, 98% of them almost pure digits.

### Changes

Table structure now lives in `lib/datasets/markdown_tables.py`, shared by workbook conversion and the chunker and free of heavy imports. A table larger than one chunk is split on row boundaries, never mid-row, with its header repeated on every chunk. Tables small enough to survive intact are deliberately left inside the surrounding prose, since the sentence before a short table is usually what explains it. This applies to worksheets, CSV exports and tables embedded in PDFs and Word documents alike.

Header detection is relative rather than absolute. Where a GitHub-style separator row exists it identifies the header and is trusted. Otherwise the header is inferred, because workbooks routinely stack title and grouping rows above the row that actually names the columns. Scoring rows by label count alone was tried first, and on a worksheet that is simply a column of labelled values it promoted a value row such as `| Pre-money valuation | CHF | 4000000 |` into every chunk of that sheet, injecting one specific number everywhere. A test for year-column headers (`| Position | 2023 | 2024 | share |`) then failed, showing that no absolute score separates the two cases. A header is now recognised by standing out from the rows beneath it. Across the 73 worksheets in the test data room that cut number-carrying headers from 29 to 7, and the 7 remaining are genuine date and calendar-week headers. Sheets that are merely labelled values correctly get no header rather than having a value row promoted.

Workbook values are rendered the way a reader would write them: `15.15` rather than `15.151515151515152`, `24.69%` rather than `0.24685415429152754`, `2026-01-19` rather than `2026-01-19 00:00:00`. Chunks from a workbook are cited by sheet name instead of `n/a`.

Cache invalidation is deliberately narrow. `PARSER_VERSION` gates *all* re-parsing, so bumping it would re-run Docling over every PDF in every dataset — huge time of vision-model work — to fix spreadsheets. Workbooks have their own invalidation through the marker comment, and chunking is gated separately by `CHUNKER_VERSION`, which re-embeds without re-parsing. Re-syncing the test data room re-converted only its 9 workbooks and touched no PDF.

### Measured impact

On a test data room of 20 documents, the index went from 3280 points to 934, a 72% reduction, while chunk quality improved:

| source | chunks before | chunks after |
|---|---|---|
| large reference CSV export (1.1 MB) | 1429 | 816 |
| wide operational workbook | 705 | 343 |
| sales-pipeline workbook | 483 | 112 |
| financial model workbook | 162 | 72 |
| whole data room | 3292 | 1750 |

In the reference CSV, chunks with no usable text fell from 467 to 1. A question about a named investor's shareholding now returns the cap-table worksheet with its header attached and cited by sheet name, where previously it returned unlabelled digits attributed to no page.

### Test plan

- [x] 566 tests pass, including 27 new ones covering header detection, header repetition, row integrity, page attribution, oversized rows, small-table inlining and value formatting
- [x] Re-synced a test data room end to end: 9 workbooks re-converted, 20 documents re-indexed, 0 failures, no PDF re-parsed
- [x] Verified live search returns table chunks with headers intact and correct sheet citations

### Notes for reviewers

The chunker cannot rescue input that carries no meaning. One workbook in the test data room is a simulation sheet of random floats and still yields 112 chunks of digits, and the largest single chunk source is a public reference table that has no bearing on the company at all. A noise guard that skips reference tables and low-signal sheets would be a reasonable follow-up, but it is a policy decision about what belongs in a data room rather than a parsing fix, so it is left out of this PR.