### PR TITLE
Contribution rules, PR template, and CI for the existing test suite

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,34 @@
+## What this changes, and why
+
+<!-- One paragraph. What problem, what you did. -->
+
+## What already existed that this uses
+
+<!-- List the existing routines you reused, by file and function name.
+     If you wrote something new that feels like it should already exist,
+     say so here - someone will know. -->
+
+-
+
+## Scope
+
+- [ ] This is additive - no existing code or config was changed
+- [ ] It changes existing code (explain below, and say who it affects)
+
+## Checks
+
+- [ ] Tests added or updated, and they run
+- [ ] `SKILL.md` written or updated, if a skill changed
+- [ ] Prompts and settings are in `config/`, not in Python
+- [ ] Output goes through `InsightFile`; no paths built by hand
+- [ ] No check was skipped, disabled or weakened to get green
+
+## What I have not verified
+
+<!-- Be specific. "Not run against a real dossier" is a useful sentence.
+     A pull request that claims everything is verified gets read with
+     more suspicion, not less. -->
+
+## Wishlist
+
+<!-- Anything you wanted to change but deliberately did not. -->

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,30 @@
+# Runs the test suite on every pull request and every push to main.
+#
+# There are ninety test files in this repository and, until now, nothing ran
+# them automatically. This is the cheapest safety net available: it uses tests
+# that already exist.
+
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: conda-incubator/setup-miniconda@v3
+        with:
+          environment-file: environment.yml
+          activate-environment: sictic-env
+          auto-activate-base: false
+
+      - name: Run the test suite
+        shell: bash -el {0}
+        env:
+          SICTIC_TESTING: "1"
+        run: pytest -q -m "not live"

--- a/AGENT_RULES.md
+++ b/AGENT_RULES.md
@@ -1,0 +1,92 @@
+# Rules of the game — for AI coding agents
+
+> Named `AGENT_RULES.md` rather than `AGENTS.md` on purpose: `AGENTS.md` is in
+> this repository's `.gitignore`, alongside the other per-machine agent files,
+> so anything written there is never committed.
+
+**Paste this to your coding agent before it writes anything, every session.**
+
+You are contributing to SICTIC-AI, a shared codebase with about ten
+contributors and a working production system behind it. Most of what you are
+asked to build already exists in some form. Your job is to find it and compose
+it, not to write it again.
+
+## Before you write a single line
+
+1. **Work from current `main`.** `git fetch origin && git merge origin/main`.
+   A stale checkout is the single most reliable way to reinvent something: the
+   routine you are about to write may have been added last week.
+2. **Read `skills/standards_and_architecture/SKILL.md` in full.** It is the
+   binding description of how this repository is laid out and how code is
+   written here. It is not background reading.
+3. **Look for what already exists.** `ls skills/` lists twenty-five
+   capabilities. `ls lib/` lists the shared infrastructure. Search before
+   building: `grep -rn "def <the-thing-you-want>" lib skills`.
+4. **Verify every name against the source.** If a document, a table, or a
+   colleague tells you a routine exists, open the file and confirm the
+   signature. Names move. A reuse list is only as good as the tree it was
+   checked against.
+
+## What you must not do
+
+* **Do not create a second way to do something that already has one.** One
+  checklist format, one checklist parser, one person model, one path resolver,
+  one way to store generated output. If the existing one does not fit, say so
+  and ask — do not fork it.
+* **Do not modify existing code to make your feature fit.** Add alongside it.
+  Propose the refactor separately, in writing, and let a human decide.
+* **Do not hardcode.** No prompts in Python, no model names, no storage paths,
+  no magic thresholds. Prompts and settings live in `config/`; paths come from
+  `lib.datasets.paths`; the model comes from `lib.model_config.llm_model`.
+* **Do not print.** Use `lib.logger.get_logger`. `print()` is reserved for final
+  output to the user.
+* **Do not weaken a check to get green.** Not a test, not a linter, not a
+  gate. If a check fails, the check is usually right.
+* **Do not claim it works because it compiles or because tests pass.** Run it
+  against real data and read the output.
+
+## The routines you are most likely to need
+
+Confirm each one against the source before using it.
+
+| you need to… | use |
+|---|---|
+| resolve a startup name | `lib.startups.identity.canonical_startup_slug` |
+| get a startup's dossier ready | `lib.startups.sources.ensure_startup_dataset`, then `lib.datasets.ingestion.sync_datasets` |
+| find where data lives | `lib.datasets.paths` — never build a path by hand |
+| ask a question of a dossier | `skills.dataset_chat.dataset_chat.dataset_chat` |
+| run a checklist over a dossier | `skills.batch_audit.batch_audit.batch_audit` |
+| parse a checklist | `skills.batch_audit.checklist.parse_checklist` — the only checklist parser |
+| render an audit as a table | `skills.batch_audit.rendering.json_to_markdown_table` |
+| force structured output from a model | `lib.structured_output` |
+| one free-form model call | `skills.llm_chat.llm_chat.llm_chat` |
+| save generated output | `lib.insights.InsightFile` — handles paths, model tags, caching, freshness |
+| represent a person | `lib.people.model.Person` — do not introduce another |
+| find people in a dossier | `lib.people.discovery.persons_in_dataset` |
+| resolve a LinkedIn profile | `lib.linkedin.LinkedInResolver` |
+| load prompts and settings | `skills.config_load.config_load.config_load` |
+| build a CLI | `lib.cli.run_command` + Typer, in a `__main__.py` with no logic in it |
+
+## The shape of a skill
+
+```text
+skills/<skill_name>/
+├── SKILL.md          what it does and how to invoke it - mandatory
+├── __init__.py
+├── __main__.py       Typer CLI. Zero business logic.
+├── <skill_name>.py   the main function, named exactly like the skill
+├── core/             (optional) heavy lifting
+└── utils/            (optional) helpers unique to this skill
+```
+
+The main function returns a flat `list[InsightFile]`, including when the result
+came from cache. If it takes a dataset, that is its first parameter.
+
+## When you finish
+
+* Tests for what you added, run and passing.
+* `SKILL.md` written for any new skill.
+* A short note of anything you wanted to change but did not — that list is more
+  valuable than a silent workaround.
+* Say plainly what you did **not** verify. "I did not run this against a real
+  startup" is useful. "Implemented successfully" is not.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,122 @@
+# Contributing to SICTIC-AI
+
+This repository is worked on by about ten people, several of them using AI
+coding agents, and it runs a live system. This page is what a new contributor
+reads first.
+
+If you are directing an AI agent, give it **`AGENT_RULES.md`** as well. It is the
+same rules, written for the agent rather than for you.
+
+---
+
+## Before you start
+
+**1. Agree what you are building, with a person.** Open an issue describing the
+problem before writing a solution. Most wasted work here is not badly written —
+it is a duplicate, or the wrong shape, and both are cheap to catch in a
+paragraph and expensive to catch in a diff.
+
+**2. Check whether it already exists.** Twenty-five skills and a shared `lib/`
+already cover a lot:
+
+```bash
+ls skills/        # the capabilities that exist
+ls lib/           # the shared infrastructure
+grep -rn "def <the-thing-you-want>" lib skills
+```
+
+**3. Read `skills/standards_and_architecture/SKILL.md`.** It is the binding
+description of the layout and the coding rules. Everything below assumes it.
+
+**4. Start from current `main`.** Not from your checkout of three weeks ago.
+This is the most common cause of accidentally rewriting something that already
+exists.
+
+---
+
+## How work should be shaped
+
+**Additive first.** A new capability is a new skill package. It composes what is
+already in `lib/` and `skills/`, and changes nothing existing. If your feature
+seems to need an existing routine changed, that is a separate conversation and a
+separate pull request — write the reasons down and let a human decide.
+
+**One way to do each thing.** One checklist format and one parser. One person
+model. One path resolver. One way to store generated output. If the existing one
+does not fit your case, say so before working around it. A second way to do
+something costs everyone, permanently.
+
+**Nothing hardcoded.** Prompts, instructions and thresholds live in `config/`
+and are loaded with `config_load()`. Paths come from `lib.datasets.paths`. The
+model comes from `lib.model_config.llm_model`. If you are typing a prompt into a
+`.py` file, stop.
+
+**Small pull requests.** One reviewable change. A large PR does not get reviewed
+carefully — it gets approved.
+
+---
+
+## What a pull request must contain
+
+* **Tests that run.** There are ninety test files in `tests/`; add to them.
+* **A `SKILL.md`** for any new skill — what it does, how it works, how to
+  invoke it.
+* **A description that says what you did not verify.** "Not yet run against a
+  real startup dossier" is a useful sentence, not an admission of failure.
+* **Green checks.** Never disable, skip or weaken a check to get there.
+
+---
+
+## Where things are stored
+
+Nothing generated goes in the repository. It goes to configured storage.
+
+| what | where |
+|---|---|
+| prompts, instructions, checklists, schemas | `config/<skill>/` |
+| raw startup and community data | the `startups` / `community` storage domains |
+| generated reports and profiles | `insights`, always through `lib.insights.InsightFile` |
+| disposable cache | `cache/` — never anything you would miss |
+
+`InsightFile` handles naming, the model tag, freshness and reuse. Do not write
+files yourself and do not construct paths by hand.
+
+---
+
+## How to document
+
+* **`SKILL.md`** — mandatory for every skill, and the first thing anyone reads.
+* **The main function's docstring** — one paragraph, plain language, describing
+  what the skill produces. It is what a person sees when they list skills.
+* **Comments** — explain *why*, not *what*. The code already says what.
+* **Leave a wishlist.** Anything you wanted to change but deliberately did not.
+  This is how the repository learns where it hurts.
+
+---
+
+## Working with AI agents
+
+Agents are already contributing here. They are fast and they are good until they
+are asked to reuse something — at which point, unprompted, they will confidently
+rewrite it.
+
+* Give the agent **`AGENT_RULES.md`** at the start of every session.
+* Make it show you which existing routines it used, **by file and function
+  name**, and check one or two.
+* Treat "successfully implemented" as an unverified claim. Ask what it ran, and
+  what it did not.
+* An agent's tests passing is not evidence the feature works. It is evidence
+  the tests pass.
+
+---
+
+## The two failures that hurt most
+
+**A stale checkout.** Six shared components were added to this repository in a
+single recent stretch. A contributor working from an old copy would not have
+seen them and would have written four of them again — while following a brief
+whose whole purpose was to prevent that.
+
+**A silent rewrite.** Building a second parser, a second person model, or a
+second way to store output does not break anything on the day. It breaks the
+next person, and the one after that, and it is never worth the time it saved.


### PR DESCRIPTION
Four additive files. Nothing existing is changed, so this is safe to read slowly.

## Why

This repository has **ninety test files that nothing ever runs**, no branch
protection, no pull-request template and no contributing guide — while about ten
people contribute, several through AI agents that already commit under their own
names.

Pull requests are already the norm here (37 of the last 60 commits on `main` are
merges), so the gap is not discipline. **Nothing checks those pull requests.**

## What is here

| file | what it does |
|---|---|
| `.github/workflows/tests.yml` | runs the existing suite on every PR |
| `.github/PULL_REQUEST_TEMPLATE.md` | asks *which existing routines did you reuse* and *what have you not verified* |
| `CONTRIBUTING.md` | what a new contributor reads first |
| `AGENT_RULES.md` | the same rules, addressed to a coding agent — the "rules of the game" blurb to paste at the start of a session |

## Two settings only an admin can change

The files alone have little force. What gives them force:

1. **Require the test run on pull requests** — after confirming it passes on
   `main`. Nothing has ever run it, so that result is worth reading before
   requiring it of anyone.
2. **Protect `main`** — pull request + passing checks + one review.

## One thing found while writing this

`AGENTS.md` is in `.gitignore`, alongside `IDENTITY.md`, `SOUL.md` and the other
per-machine agent files. Anything written there is never committed — which may
explain why a primer under that name has not stuck before. Hence
`AGENT_RULES.md`.

## Where the rules come from

Not from theory. From failures hit while building against this repository:

* a checkout **58 commits behind** `main`, missing six shared components —
  `lib/structured_output.py`, four `batch_audit` modules, the whole `sha_review`
  skill — that a contributor would otherwise have written again;
* **three entries in a reuse list that no longer matched the source**, including
  one routine that does not exist;
* a rule that **looked enforced and silently was not**, because a vocabulary had
  drifted underneath it.

Each is a case of an agent doing exactly as it was told and still duplicating
work. Hence the two rules `AGENT_RULES.md` leads with: *work from current main*,
and *verify every name against the source*.

Draft, so it lands only if and when you want it.
