### PR TITLE
fix(startup_profile): reject empty LLM output instead of caching it

### DIFF
--- a/skills/startup_profile/startup_profile.py
+++ b/skills/startup_profile/startup_profile.py
@@ -56,7 +56,7 @@ async def startup_profile(startup: str, files: Optional[List[str]] = None) -> In
         ),
     )
 
-    if profile_output is None:
-        raise ValueError("LLM returned None for the profile output.")
+    if not profile_output or not profile_output.strip():
+        raise ValueError("LLM returned an empty response for the profile output.")
     insight.save(profile_output)
     return [insight]

--- a/tests/startup_profile/test_startup_profile.py
+++ b/tests/startup_profile/test_startup_profile.py
@@ -38,6 +38,40 @@ async def test_startup_profile_saves_empty_context_response(mock_env, mocker):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("empty_output", ["", "   "])
+async def test_startup_profile_rejects_empty_llm_output(mock_env, mocker, empty_output):
+    get_storage().mkdir(
+        dataset_location_for_domain("avientus", "startups").raw_rel
+    )
+    mocker.patch(
+        "skills.startup_profile.startup_profile.InsightFile.find",
+        return_value=None,
+    )
+    mocker.patch("skills.startup_profile.startup_profile.sync_datasets")
+    save = mocker.patch(
+        "skills.startup_profile.startup_profile.InsightFile.save"
+    )
+    mocker.patch(
+        "skills.startup_profile.startup_profile.config_load",
+        return_value={
+            "startup_profile": {
+                "query": "Profile this startup.",
+                "llm_instructions": "Use only context.",
+            }
+        },
+    )
+    mocker.patch(
+        "skills.startup_profile.startup_profile.dataset_chat",
+        return_value=empty_output,
+    )
+
+    with pytest.raises(ValueError, match="empty response"):
+        await startup_profile("Avientus")
+
+    save.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_startup_profile_splits_query_lines_for_retrieval(mock_env, mocker):
     get_storage().mkdir(
         dataset_location_for_domain("avientus", "startups").raw_rel


### PR DESCRIPTION
Fixes #53

**What was wrong:** the guard on the LLM output only rejected `None`, but the LLM layer can return an empty string (`llm_chat` logs "Received an empty response" and returns it; `dataset_chat` passes it through). The empty profile was saved and registered as a fresh, reusable insight, so every later run and downstream skill (`expert_search`, `potential_investors`) served it until the dataset revision or config changed.

**Fix:** reject empty/whitespace output too, matching the existing pattern in `person_profile`: `if not profile_output or not profile_output.strip()`.

**Test:** new `test_startup_profile_rejects_empty_llm_output`, parametrized over `""` and `"   "`, asserts `ValueError` is raised and `InsightFile.save` is not called. All 4 tests in `tests/startup_profile` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)