### PR TITLE
Fix local LLM schema failures and hour-long timeouts

### DIFF
--- a/.env-template
+++ b/.env-template
@@ -34,8 +34,19 @@ RERANK_API_KEY=
 
 CLOUD_TPM_BUDGET=1000000
 
+# LLM_REQUEST_TIMEOUT is the HTTP ceiling for free-form completions (seconds).
+# Structured JSON calls use the shorter LLM_STRUCTURED_REQUEST_TIMEOUT instead
+# of retrying a one-hour hang three times. GATEWAY_LEASE_MAX_AGE must be at
+# least as long as the longest of these, or a still-running call loses its slot.
+LLM_REQUEST_TIMEOUT=3600
+LLM_STRUCTURED_REQUEST_TIMEOUT=180
+LLM_STRUCTURED_NUM_PREDICT=4096
+GATEWAY_LEASE_MAX_AGE=3600
+
 OLLAMA_CONTEXT_LENGTH=32768
 OLLAMA_CONTEXT_LENGTH_MAX=262144
+# 8-way decode is fine for small local models. A 27B-class Qwen on one GPU
+# should use 1 or 2, or KV-cache thrash will look like a 3600s timeout.
 OLLAMA_NUM_PARALLEL=8
 OLLAMA_MAX_LOADED_MODELS=2
 OLLAMA_KV_CACHE_TYPE=q8_0

--- a/docs/installation-and-operations.md
+++ b/docs/installation-and-operations.md
@@ -81,6 +81,15 @@ are:
   endpoint, and API key. Blank `RERANK_MODEL` disables reranking.
 - `RETRIEVAL_*`: how wide retrieval runs and how much of an answer one document
   may occupy. See [Retrieval](#retrieval).
+- `LLM_REQUEST_TIMEOUT`: HTTP ceiling in seconds for free-form completions
+  (default 3600). Structured JSON calls use `LLM_STRUCTURED_REQUEST_TIMEOUT`
+  (default 180) and `LLM_STRUCTURED_NUM_PREDICT` (default 4096).
+- `GATEWAY_LEASE_MAX_AGE`: how long a gateway slot may be held before it is
+  treated as leaked. It is raised automatically to cover the longest LLM HTTP
+  timeout, so a still-running call cannot lose its slot to a second job.
+- `OLLAMA_NUM_PARALLEL`: concurrent local decode slots. Keep this at 1 or 2
+  for 27B-class models; the default of 8 is aimed at small 8B models. Too many
+  slots on a large model saturates KV cache and surfaces as hour-long timeouts.
 
 The complete set and its local defaults are in `.env-template`. Optional Google
 Drive synchronization is configured independently under `rclone-sync/`; it is
@@ -241,6 +250,23 @@ a share price becomes `15.15` rather than `15.151515151515152`, a
 percent-formatted cell becomes `24.69%` rather than `0.24685415429152754`, and a
 date becomes `2026-01-19`. Chunks from a workbook are cited by sheet name
 instead of a page number.
+
+## Local LLM timeouts and structured JSON
+
+Due-diligence skills ask the model for JSON that matches a schema. Local Qwen
+3.x models default to a thinking mode that both inflates latency and wraps JSON
+in `<think>` tags the schema cannot accept. Structured calls therefore disable
+thinking, send the schema through Ollama's native `format` field, and cap the
+number of generated tokens.
+
+Free-form completions may still run up to `LLM_REQUEST_TIMEOUT` (one hour by
+default). A JSON object that is not back within
+`LLM_STRUCTURED_REQUEST_TIMEOUT` is a failed request, not a slow one: schema
+retries do not repeat timeouts, and a timed-out audit check is recorded as an
+error instead of occupying the GPU for three hours.
+
+On a 27B local model, set `OLLAMA_NUM_PARALLEL=1` or `2`. Eight parallel slots
+are only appropriate for the small default 8B models.
 
 ### Upgrading an existing index
 

--- a/lib/json_parser.py
+++ b/lib/json_parser.py
@@ -7,6 +7,21 @@ logger = get_logger(__name__)
 
 
 _VALID_JSON_ESCAPES = {'"', "\\", "/", "b", "f", "n", "r", "t"}
+_REASONING_BLOCK_RE = re.compile(
+    r"<(think|thinking|reason|reasoning)>\s*.*?</\1>\s*",
+    re.IGNORECASE | re.DOTALL,
+)
+_UNCLOSED_REASONING_RE = re.compile(
+    r"^<(think|thinking|reason|reasoning)>.*",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def strip_reasoning_tags(raw_output: str) -> str:
+    """Remove chain-of-thought wrappers that local models put around JSON."""
+    stripped = _REASONING_BLOCK_RE.sub("", raw_output)
+    stripped = _UNCLOSED_REASONING_RE.sub("", stripped)
+    return stripped.strip()
 
 
 def _escape_invalid_json_backslashes(json_str: str) -> str:
@@ -132,7 +147,11 @@ def repair_json_payload(raw_output: str) -> dict | list:
     """Extracts and parses JSON from a raw LLM string."""
     if not raw_output:
         raise ValueError("Empty response from LLM.")
-        
+
+    raw_output = strip_reasoning_tags(raw_output)
+    if not raw_output:
+        raise ValueError("Empty response from LLM.")
+
     # 1. Try to find a markdown JSON block first
     match = re.search(r'```(?:json)?\s*([\s\S]*?)\s*```', raw_output)
     if match:

--- a/lib/llm_timeouts.py
+++ b/lib/llm_timeouts.py
@@ -1,0 +1,67 @@
+"""Shared LLM HTTP timeout defaults.
+
+Structured JSON calls must fail fast. Unbounded thinking plus a one-hour
+retry loop is how a single due-diligence check stalls for hours.
+"""
+
+from __future__ import annotations
+
+import os
+
+from lib.logger import get_logger
+
+logger = get_logger(__name__)
+
+DEFAULT_LLM_REQUEST_TIMEOUT = 3600.0
+DEFAULT_STRUCTURED_REQUEST_TIMEOUT = 180.0
+DEFAULT_STRUCTURED_NUM_PREDICT = 4096
+
+
+def float_env(name: str, default: float) -> float:
+    raw = os.environ.get(name)
+    if raw is None or not raw.strip():
+        return default
+    try:
+        return float(raw)
+    except ValueError:
+        logger.warning("Ignoring non-numeric %s=%r", name, raw)
+        return default
+
+
+def int_env(name: str, default: int) -> int:
+    return int(float_env(name, float(default)))
+
+
+def llm_request_timeout() -> float:
+    return float_env("LLM_REQUEST_TIMEOUT", DEFAULT_LLM_REQUEST_TIMEOUT)
+
+
+def structured_request_timeout() -> float:
+    return float_env(
+        "LLM_STRUCTURED_REQUEST_TIMEOUT",
+        DEFAULT_STRUCTURED_REQUEST_TIMEOUT,
+    )
+
+
+def structured_num_predict() -> int:
+    return max(
+        1,
+        int_env("LLM_STRUCTURED_NUM_PREDICT", DEFAULT_STRUCTURED_NUM_PREDICT),
+    )
+
+
+def effective_request_timeout(
+    *,
+    structured: bool,
+    override: float | None = None,
+) -> float:
+    if override is not None:
+        return override
+    if structured:
+        return structured_request_timeout()
+    return llm_request_timeout()
+
+
+def lease_floor_seconds() -> float:
+    """Gateway leases must outlive the longest in-flight LLM HTTP call."""
+    return max(llm_request_timeout(), structured_request_timeout())

--- a/lib/services_gateway.py
+++ b/lib/services_gateway.py
@@ -13,6 +13,11 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, AsyncIterator
 
+from lib.llm_timeouts import (
+    DEFAULT_LLM_REQUEST_TIMEOUT,
+    float_env,
+    lease_floor_seconds,
+)
 from lib.logger import get_logger
 
 logger = get_logger(__name__)
@@ -23,23 +28,14 @@ _POLL_INTERVAL = 0.05
 # A lease held longer than this is treated as leaked and reclaimed even if
 # the owning process is still alive: a hung provider call never returns, so
 # pid-liveness alone cannot distinguish a stuck job from a long one.
-_DEFAULT_LEASE_MAX_AGE = 1800.0
-_DEFAULT_LLM_REQUEST_TIMEOUT = 600.0
+# Must be at least as long as the LLM HTTP timeout, or a still-running call
+# loses its slot and a second job starts on the same GPU.
+_DEFAULT_LEASE_MAX_AGE = DEFAULT_LLM_REQUEST_TIMEOUT
+_DEFAULT_LLM_REQUEST_TIMEOUT = DEFAULT_LLM_REQUEST_TIMEOUT
 _DEFAULT_EMBEDDING_REQUEST_TIMEOUT = 300.0
 _DEFAULT_RERANK_REQUEST_TIMEOUT = 120.0
 _CLOUD_BUDGET_WINDOW_SECONDS = 60.0
 _LOCAL_MODEL_PREFIXES = ("ollama/", "mlx/")
-
-
-def _float_env(name: str, default: float) -> float:
-    raw = os.environ.get(name)
-    if raw is None or not raw.strip():
-        return default
-    try:
-        return float(raw)
-    except ValueError:
-        logger.warning("Ignoring non-numeric %s=%r", name, raw)
-        return default
 
 
 class GatewayTimeoutError(TimeoutError):
@@ -153,11 +149,13 @@ class ServicesGateway:
         )
         self.wait_timeout = wait_timeout
         self.poll_interval = poll_interval
-        self.lease_max_age = (
-            lease_max_age
-            if lease_max_age is not None
-            else _float_env("GATEWAY_LEASE_MAX_AGE", _DEFAULT_LEASE_MAX_AGE)
-        )
+        if lease_max_age is not None:
+            self.lease_max_age = lease_max_age
+        else:
+            self.lease_max_age = max(
+                float_env("GATEWAY_LEASE_MAX_AGE", _DEFAULT_LEASE_MAX_AGE),
+                lease_floor_seconds(),
+            )
         self.cloud_tpm_budget = (
             cloud_tpm_budget
             if cloud_tpm_budget is not None
@@ -626,7 +624,7 @@ class ServicesGateway:
         # its lease instead of blocking the machine-wide slot forever.
         kwargs.setdefault(
             "timeout",
-            _float_env(
+            float_env(
                 "EMBEDDING_REQUEST_TIMEOUT",
                 _DEFAULT_EMBEDDING_REQUEST_TIMEOUT,
             ),
@@ -658,7 +656,7 @@ class ServicesGateway:
         # its lease instead of blocking the machine-wide slot forever.
         kwargs.setdefault(
             "timeout",
-            _float_env(
+            float_env(
                 "LLM_REQUEST_TIMEOUT",
                 _DEFAULT_LLM_REQUEST_TIMEOUT,
             ),
@@ -688,7 +686,7 @@ class ServicesGateway:
         litellm.disable_aiohttp_transport = True
         kwargs.setdefault(
             "timeout",
-            _float_env(
+            float_env(
                 "RERANK_REQUEST_TIMEOUT",
                 _DEFAULT_RERANK_REQUEST_TIMEOUT,
             ),

--- a/lib/structured_output.py
+++ b/lib/structured_output.py
@@ -39,6 +39,35 @@ def schema_prompt_block(schema: dict[str, Any]) -> str:
     return template.replace(placeholder, schema_text(schema))
 
 
+def is_llm_timeout(error: BaseException) -> bool:
+    """Return whether an exception is a provider, HTTP, or gateway timeout."""
+    seen: set[int] = set()
+    current: BaseException | None = error
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        if isinstance(current, TimeoutError):
+            return True
+        name = type(current).__name__.lower()
+        message = str(current).lower()
+        if "timeout" in name or "timed out" in message:
+            return True
+        current = current.__cause__ or current.__context__
+    return False
+
+
+def is_retryable_structured_error(error: BaseException) -> bool:
+    """Retry schema/parse failures only; never retry timeouts or transport."""
+    return isinstance(error, ValueError) and not is_llm_timeout(error)
+
+
+def structured_correction_feedback(error: BaseException) -> str:
+    return (
+        "\n\n### CORRECTION REQUIRED\n\n"
+        f"Your previous response was invalid: {error}\n"
+        "Try again and return only a JSON object matching the schema."
+    )
+
+
 def json_schema_response_format(
     name: str,
     schema: dict[str, Any],

--- a/skills/batch_audit/structured.py
+++ b/skills/batch_audit/structured.py
@@ -12,8 +12,10 @@ from lib.model_config import llm_model
 from lib.slugify import slugify
 from lib.structured_output import (
     copy_schema,
+    is_retryable_structured_error,
     json_schema_response_format,
     schema_prompt_block,
+    structured_correction_feedback,
     validate_json_schema,
 )
 from skills.batch_audit.checklist import ChecklistCheck, parse_checklist
@@ -192,6 +194,8 @@ async def _run_check(
                 status_scale,
             )
         except Exception as error:
+            if not is_retryable_structured_error(error):
+                return _error_result(error)
             errors.append(str(error))
             logger.warning(
                 "[%s] Audit check %s failed on attempt %d/%d: %s",
@@ -202,12 +206,7 @@ async def _run_check(
                 error,
             )
             if attempt < MAX_ATTEMPTS:
-                retry_feedback = (
-                    "\n\n### CORRECTION REQUIRED\n\n"
-                    f"Your previous response was invalid: {error}\n"
-                    "Try again and return only a JSON object matching "
-                    "the schema."
-                )
+                retry_feedback = structured_correction_feedback(error)
     return _error_result(
         RuntimeError(
             f"Audit check failed after {MAX_ATTEMPTS} attempts: "

--- a/skills/dataset_chat/dataset_chat.py
+++ b/skills/dataset_chat/dataset_chat.py
@@ -33,6 +33,7 @@ async def dataset_chat(
     strict_insufficient_context: bool = True,
     response_format: Optional[Any] = None,
     cacheable_prompt_prefix: Optional[str] = None,
+    timeout: Optional[float] = None,
 ) -> Optional[str]:
     """Run one RAG using search queries and an independent LLM prompt."""
     if isinstance(queries, str):
@@ -108,4 +109,5 @@ async def dataset_chat(
         prompt=dynamic_prompt,
         response_format=response_format,
         cacheable_prompt_prefix=stable_prefix,
+        timeout=timeout,
     )

--- a/skills/dd_checks/dd_checks.py
+++ b/skills/dd_checks/dd_checks.py
@@ -16,8 +16,10 @@ from lib.datasets.ingestion import sync_datasets
 from lib.datasets.paths import dataset_raw_path
 from lib.structured_output import (
     copy_schema,
+    is_retryable_structured_error,
     json_schema_response_format,
     schema_prompt_block,
+    structured_correction_feedback,
     validate_json_schema,
 )
 from skills.dataset_chat.dataset_chat import _fallback_trigger
@@ -132,6 +134,8 @@ async def find_industry_type(
                 base_schema,
             )
         except Exception as error:
+            if not is_retryable_structured_error(error):
+                raise
             errors.append(str(error))
             logger.warning(
                 "[%s] Industry classification failed on attempt %d/%d: %s",
@@ -141,12 +145,7 @@ async def find_industry_type(
                 error,
             )
             if attempt < _STRUCTURED_OUTPUT_ATTEMPTS:
-                retry_feedback = (
-                    "\n\n### CORRECTION REQUIRED\n\n"
-                    f"Your previous response was invalid: {error}\n"
-                    "Try again and return only a JSON object matching "
-                    "the schema."
-                )
+                retry_feedback = structured_correction_feedback(error)
 
     raise RuntimeError(
         "Industry classification failed after "

--- a/skills/llm_chat/llm_chat.py
+++ b/skills/llm_chat/llm_chat.py
@@ -6,6 +6,10 @@ from lib.runtime_noise import configure_runtime_noise
 configure_runtime_noise()
 
 from litellm.exceptions import APIConnectionError
+from lib.llm_timeouts import (
+    effective_request_timeout,
+    structured_num_predict,
+)
 from lib.services_gateway import gateway
 from lib.env import get_env_var
 from lib.logger import get_logger
@@ -13,16 +17,40 @@ from lib.model_config import llm_endpoint
 
 logger = get_logger(__name__)
 
+
 def _supports_explicit_prompt_caching(model: str) -> bool:
     if model.startswith(("ollama/", "mlx/")):
         return False
     return model.rsplit("/", 1)[-1].startswith("gpt-5.6")
 
 
+def ollama_format_from_response_format(response_format: Any) -> dict | str:
+    """Map LiteLLM json_schema payloads onto Ollama's native format field."""
+    if isinstance(response_format, dict):
+        schema = None
+        if response_format.get("type") == "json_schema":
+            schema = (response_format.get("json_schema") or {}).get("schema")
+        if isinstance(schema, dict) and schema:
+            return schema
+    return "json"
+
+
+def apply_ollama_structured_options(
+    kwargs: dict[str, Any],
+    response_format: Any,
+) -> None:
+    """Constrain local JSON calls: no thinking, native schema, bounded decode."""
+    kwargs["think"] = False
+    kwargs["format"] = ollama_format_from_response_format(response_format)
+    kwargs["num_predict"] = structured_num_predict()
+    kwargs.pop("response_format", None)
+
+
 async def llm_chat(
     prompt: str,
     response_format: Optional[Any] = None,
     cacheable_prompt_prefix: Optional[str] = None,
+    timeout: Optional[float] = None,
 ) -> Optional[str]:
     endpoint = llm_endpoint()
     default_model = endpoint.model
@@ -69,7 +97,15 @@ async def llm_chat(
     else:
         messages = [{"role": "user", "content": full_prompt}]
     kwargs: Dict[str, Any] = endpoint.litellm_kwargs()
-    kwargs.update({"messages": messages, "timeout": 3600.0})
+    kwargs.update(
+        {
+            "messages": messages,
+            "timeout": effective_request_timeout(
+                structured=response_format is not None,
+                override=timeout,
+            ),
+        }
+    )
 
     if use_explicit_cache:
         # LiteLLM 1.97 still drops prompt_cache_key when supplied as a named
@@ -86,13 +122,16 @@ async def llm_chat(
             }
         )
         kwargs["extra_body"] = extra_body
-    
+
     if response_format:
-        kwargs["response_format"] = response_format
+        if is_ollama:
+            apply_ollama_structured_options(kwargs, response_format)
+        else:
+            kwargs["response_format"] = response_format
 
     if is_ollama:
         kwargs["num_ctx"] = ctx
-    
+
     logger.info(f"Sending request to {default_model} with context {ctx} (estimated tokens: {estimated_tokens})...")
     try:
         response = await gateway.request_completion(kwargs)

--- a/skills/ranking/ranking_rationale.py
+++ b/skills/ranking/ranking_rationale.py
@@ -4,8 +4,10 @@ from lib.json_parser import repair_json_payload
 from lib.logger import get_logger
 from lib.structured_output import (
     copy_schema,
+    is_retryable_structured_error,
     json_schema_response_format,
     schema_prompt_block,
+    structured_correction_feedback,
     validate_json_schema,
 )
 from skills.config_load.config_load import config_load
@@ -104,6 +106,8 @@ async def ranking_rationale(
                 profile_ids,
             )
         except Exception as error:
+            if not is_retryable_structured_error(error):
+                raise
             errors.append(str(error))
             logger.warning(
                 "Ranking rationale failed on attempt %d/%d: %s",
@@ -112,12 +116,7 @@ async def ranking_rationale(
                 error,
             )
             if attempt < _STRUCTURED_OUTPUT_ATTEMPTS:
-                retry_feedback = (
-                    "\n\n### CORRECTION REQUIRED\n\n"
-                    f"Your previous response was invalid: {error}\n"
-                    "Try again and return only a JSON object matching "
-                    "the schema."
-                )
+                retry_feedback = structured_correction_feedback(error)
             continue
 
         break

--- a/skills/ranking/ranking_top_k.py
+++ b/skills/ranking/ranking_top_k.py
@@ -7,8 +7,10 @@ from lib.json_parser import repair_json_payload
 from lib.logger import get_logger
 from lib.structured_output import (
     copy_schema,
+    is_retryable_structured_error,
     json_schema_response_format,
     schema_prompt_block,
+    structured_correction_feedback,
     validate_json_schema,
 )
 from skills.config_load.config_load import config_load
@@ -147,6 +149,8 @@ async def rank_chunk(objective: str, profiles: Dict[str, str]) -> List[str]:
                     f"missing={inspection.missing}."
                 )
         except Exception as error:
+            if not is_retryable_structured_error(error):
+                raise
             attempt_errors.append(str(error))
             logger.warning(
                 "Ranking model returned an invalid response on attempt "
@@ -156,12 +160,7 @@ async def rank_chunk(objective: str, profiles: Dict[str, str]) -> List[str]:
                 error,
             )
             if attempt < _RANKING_ATTEMPTS:
-                retry_feedback = (
-                    "\n\n### CORRECTION REQUIRED\n\n"
-                    f"Your previous response was invalid: {error}\n"
-                    "Try again and return only a JSON object matching "
-                    "the schema."
-                )
+                retry_feedback = structured_correction_feedback(error)
             continue
 
         return inspection.ranked_ids

--- a/skills/sha_review/sha_review.py
+++ b/skills/sha_review/sha_review.py
@@ -15,8 +15,10 @@ from lib.startups.sources import ensure_startup_dataset
 from lib.storage import get_storage
 from lib.structured_output import (
     copy_schema,
+    is_retryable_structured_error,
     json_schema_response_format,
     schema_prompt_block,
+    structured_correction_feedback,
     validate_json_schema,
 )
 from skills.batch_audit.batch_audit import batch_audit
@@ -106,6 +108,8 @@ async def _identify_sha(
                 )
             result = _parse_identification(raw_response, response_schema)
         except Exception as error:
+            if not is_retryable_structured_error(error):
+                raise
             errors.append(str(error))
             logger.warning(
                 "[%s] SHA document identification failed on attempt "
@@ -116,12 +120,7 @@ async def _identify_sha(
                 error,
             )
             if attempt < _STRUCTURED_OUTPUT_ATTEMPTS:
-                retry_feedback = (
-                    "\n\n### CORRECTION REQUIRED\n\n"
-                    f"Your previous response was invalid: {error}\n"
-                    "Try again and return only a JSON object matching "
-                    "the schema."
-                )
+                retry_feedback = structured_correction_feedback(error)
             continue
 
         break
@@ -290,6 +289,8 @@ async def _rank_templates(
                     "template."
                 )
         except Exception as error:
+            if not is_retryable_structured_error(error):
+                raise
             errors.append(str(error))
             logger.warning(
                 "SHA template ranking failed on attempt %d/%d: %s",
@@ -298,12 +299,7 @@ async def _rank_templates(
                 error,
             )
             if attempt < _STRUCTURED_OUTPUT_ATTEMPTS:
-                retry_feedback = (
-                    "\n\n### CORRECTION REQUIRED\n\n"
-                    f"Your previous response was invalid: {error}\n"
-                    "Try again and return only a JSON object matching "
-                    "the schema."
-                )
+                retry_feedback = structured_correction_feedback(error)
             continue
 
         break

--- a/skills/submission_ready/submission_ready.py
+++ b/skills/submission_ready/submission_ready.py
@@ -29,8 +29,10 @@ from lib.startups.dealum import (
 from lib.storage import get_storage
 from lib.structured_output import (
     copy_schema,
+    is_retryable_structured_error,
     json_schema_response_format,
     schema_prompt_block,
+    structured_correction_feedback,
     validate_json_schema,
 )
 from skills.batch_audit.batch_audit import batch_audit
@@ -289,6 +291,8 @@ async def _generate_proposed_action(
                 effective_schema,
             )
         except Exception as error:
+            if not is_retryable_structured_error(error):
+                raise
             errors.append(str(error))
             logger.warning(
                 "Proposed-action analysis failed on attempt %d/%d: %s",
@@ -297,12 +301,7 @@ async def _generate_proposed_action(
                 error,
             )
             if attempt < MAX_ATTEMPTS:
-                retry_feedback = (
-                    "\n\n### CORRECTION REQUIRED\n\n"
-                    f"Your previous response was invalid: {error}\n"
-                    "Try again and return only a JSON object matching "
-                    "the schema."
-                )
+                retry_feedback = structured_correction_feedback(error)
             continue
 
         break

--- a/tests/dataset_chat/test_dataset_chat.py
+++ b/tests/dataset_chat/test_dataset_chat.py
@@ -113,6 +113,7 @@ async def test_dataset_chat_forwards_response_format(mocker):
     )
 
     assert mock_llm.await_args.kwargs["response_format"] is response_format
+    assert mock_llm.await_args.kwargs["timeout"] is None
 
 
 @pytest.mark.asyncio

--- a/tests/llm_chat/test_llm_chat.py
+++ b/tests/llm_chat/test_llm_chat.py
@@ -32,6 +32,8 @@ async def test_ollama_requests_always_include_computed_num_ctx(monkeypatch, mock
     monkeypatch.setenv("LLM_BASE_URL", "http://localhost:11434")
     monkeypatch.setenv("OLLAMA_CONTEXT_LENGTH", "4096")
     monkeypatch.setenv("OLLAMA_CONTEXT_LENGTH_MAX", "8192")
+    monkeypatch.delenv("LLM_STRUCTURED_REQUEST_TIMEOUT", raising=False)
+    monkeypatch.delenv("LLM_STRUCTURED_NUM_PREDICT", raising=False)
     mocker.patch.object(module.gateway, "request_completion", side_effect=fake_completion)
     log_info = mocker.patch.object(module.logger, "info")
 
@@ -50,7 +52,11 @@ async def test_ollama_requests_always_include_computed_num_ctx(monkeypatch, mock
 
     assert result == "ok"
     assert captured["num_ctx"] == 4096
-    assert captured["response_format"] == response_format
+    assert captured["think"] is False
+    assert captured["format"] == {"type": "object"}
+    assert captured["num_predict"] == 4096
+    assert captured["timeout"] == 180.0
+    assert "response_format" not in captured
     log_info.assert_any_call("LLM usage for %s: %s", "ollama/example", usage)
 
 
@@ -122,6 +128,7 @@ async def test_ollama_does_not_receive_openai_cache_parameters(monkeypatch, mock
     monkeypatch.setenv("LLM_BASE_URL", "http://localhost:11434")
     monkeypatch.setenv("OLLAMA_CONTEXT_LENGTH", "4096")
     monkeypatch.setenv("OLLAMA_CONTEXT_LENGTH_MAX", "8192")
+    monkeypatch.delenv("LLM_REQUEST_TIMEOUT", raising=False)
     mocker.patch.object(module.gateway, "request_completion", side_effect=fake_completion)
 
     await module.llm_chat(
@@ -133,3 +140,73 @@ async def test_ollama_does_not_receive_openai_cache_parameters(monkeypatch, mock
         {"role": "user", "content": "stable prefix\n\ndynamic question"}
     ]
     assert "extra_body" not in captured
+    assert captured["timeout"] == 3600.0
+    assert "think" not in captured
+    assert "format" not in captured
+
+
+@pytest.mark.asyncio
+async def test_cloud_structured_calls_keep_openai_response_format(
+    monkeypatch,
+    mocker,
+):
+    from skills.llm_chat import llm_chat as module
+
+    captured = {}
+
+    async def fake_completion(kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(
+            usage=None,
+            choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))],
+        )
+
+    monkeypatch.setenv("LLM_MODEL", "openai/gpt-5.6-luna")
+    monkeypatch.setenv("OLLAMA_CONTEXT_LENGTH", "4096")
+    monkeypatch.setenv("OLLAMA_CONTEXT_LENGTH_MAX", "8192")
+    monkeypatch.delenv("LLM_STRUCTURED_REQUEST_TIMEOUT", raising=False)
+    mocker.patch.object(module.gateway, "request_completion", side_effect=fake_completion)
+
+    response_format = {
+        "type": "json_schema",
+        "json_schema": {
+            "name": "fixture",
+            "strict": True,
+            "schema": {"type": "object"},
+        },
+    }
+    await module.llm_chat("short prompt", response_format=response_format)
+
+    assert captured["response_format"] is response_format
+    assert captured["timeout"] == 180.0
+    assert "think" not in captured
+    assert "format" not in captured
+
+
+@pytest.mark.asyncio
+async def test_explicit_timeout_overrides_structured_default(monkeypatch, mocker):
+    from skills.llm_chat import llm_chat as module
+
+    captured = {}
+
+    async def fake_completion(kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(
+            usage=None,
+            choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))],
+        )
+
+    monkeypatch.setenv("LLM_MODEL", "ollama/example")
+    monkeypatch.setenv("LLM_BASE_URL", "http://localhost:11434")
+    monkeypatch.setenv("OLLAMA_CONTEXT_LENGTH", "4096")
+    monkeypatch.setenv("OLLAMA_CONTEXT_LENGTH_MAX", "8192")
+    mocker.patch.object(module.gateway, "request_completion", side_effect=fake_completion)
+
+    await module.llm_chat(
+        "short prompt",
+        response_format={"type": "json_object"},
+        timeout=42,
+    )
+
+    assert captured["timeout"] == 42
+    assert captured["format"] == "json"

--- a/tests/ranking/test_ranking_rationale.py
+++ b/tests/ranking/test_ranking_rationale.py
@@ -68,6 +68,31 @@ async def test_ranking_rationale_propagates_invalid_response(mocker):
 
 
 @pytest.mark.asyncio
+async def test_ranking_rationale_does_not_retry_timeouts(mocker):
+    mocker.patch(
+        "skills.ranking.ranking_rationale.config_load",
+        return_value={
+            "ranking_rationale": {
+                "rationale_instructions": "{{objective}}\n{{profiles_text}}",
+                "response_schema": RESPONSE_SCHEMA,
+            }
+        },
+    )
+    mock_llm = mocker.patch(
+        "skills.ranking.ranking_rationale.llm_chat",
+        side_effect=TimeoutError("LLM request timed out after 180s"),
+    )
+
+    with pytest.raises(TimeoutError, match="timed out"):
+        await ranking_rationale(
+            [{"id": "urs-gubser", "text": "Profile", "rank": 1}],
+            objective="Find experts",
+        )
+
+    assert mock_llm.await_count == 1
+
+
+@pytest.mark.asyncio
 async def test_ranking_rationale_retries_with_validation_feedback(mocker):
     mocker.patch(
         "skills.ranking.ranking_rationale.config_load",

--- a/tests/skills/test_structured_batch_audit.py
+++ b/tests/skills/test_structured_batch_audit.py
@@ -270,14 +270,16 @@ async def test_structured_batch_audit_preserves_missing_evidence_fallback(
 
 
 @pytest.mark.asyncio
-async def test_structured_batch_audit_records_exhausted_errors(
+async def test_structured_batch_audit_records_exhausted_schema_errors(
     mock_env,
     monkeypatch,
 ):
     _indexed_dataset()
+    calls = {"count": 0}
 
     async def failing_dataset_chat(**_kwargs):
-        raise RuntimeError("provider unavailable")
+        calls["count"] += 1
+        raise ValueError("LLM response does not match the schema at $.status")
 
     monkeypatch.setattr(
         "skills.batch_audit.structured.dataset_chat",
@@ -294,6 +296,7 @@ async def test_structured_batch_audit_records_exhausted_errors(
     )
 
     checks = json.loads(insight.content())["chapters"][0]["checks"]
+    assert calls["count"] == 6
     assert all(check["status"] is None for check in checks)
     assert all("failed after 3 attempts" in check["error"] for check in checks)
 
@@ -324,6 +327,38 @@ async def test_structured_batch_audit_records_exhausted_errors(
     recovered_checks = json.loads(recovered.content())["chapters"][0]["checks"]
     assert all(check["status"] == "Pass" for check in recovered_checks)
     assert all(check["error"] is None for check in recovered_checks)
+
+
+@pytest.mark.asyncio
+async def test_structured_batch_audit_does_not_retry_timeouts(
+    mock_env,
+    monkeypatch,
+):
+    _indexed_dataset()
+    calls = {"count": 0}
+
+    async def timing_out_dataset_chat(**_kwargs):
+        calls["count"] += 1
+        raise TimeoutError("LLM request timed out after 180s")
+
+    monkeypatch.setattr(
+        "skills.batch_audit.structured.dataset_chat",
+        timing_out_dataset_chat,
+    )
+
+    insight = await batch_audit_json(
+        dataset_name="example-startup",
+        skill_name="submission_ready",
+        checklist_markdown=CHECKLIST,
+        llm_instructions="Return JSON.",
+        status_scale=["Pass", "Fail", "Unclear"],
+        missing_evidence_status="Unclear",
+    )
+
+    checks = json.loads(insight.content())["chapters"][0]["checks"]
+    assert calls["count"] == 2
+    assert all("timed out" in check["error"] for check in checks)
+    assert all("failed after 3 attempts" not in check["error"] for check in checks)
 
 
 @pytest.mark.asyncio

--- a/tests/utils/test_json_parser.py
+++ b/tests/utils/test_json_parser.py
@@ -78,3 +78,21 @@ def test_repair_json_payload_combines_backslash_and_trailing_comma_repairs():
 def test_repair_json_payload_does_not_repair_unquoted_property_names():
     with pytest.raises(ValueError, match="Expecting property name"):
         repair_json_payload('{startup_name: "Acme",}')
+
+
+def test_repair_json_payload_strips_think_blocks():
+    result = repair_json_payload(
+        "<think>The answer should be JSON.</think>\n"
+        '{"value": "ok"}'
+    )
+
+    assert result == {"value": "ok"}
+
+
+def test_repair_json_payload_strips_reasoning_blocks_around_fences():
+    result = repair_json_payload(
+        "<reasoning>planning</reasoning>\n"
+        '```json\n{"value":"ok"}\n```'
+    )
+
+    assert result == {"value": "ok"}

--- a/tests/utils/test_services_gateway.py
+++ b/tests/utils/test_services_gateway.py
@@ -44,6 +44,15 @@ def test_default_poll_interval_is_fifty_milliseconds(tmp_path):
     assert gateway.poll_interval == 0.05
 
 
+def test_lease_max_age_covers_llm_request_timeout(monkeypatch, tmp_path):
+    monkeypatch.delenv("GATEWAY_LEASE_MAX_AGE", raising=False)
+    monkeypatch.setenv("LLM_REQUEST_TIMEOUT", "7200")
+    monkeypatch.setenv("LLM_STRUCTURED_REQUEST_TIMEOUT", "180")
+    gateway = ServicesGateway(state_path=tmp_path / "gateway.json")
+
+    assert gateway.lease_max_age == 7200.0
+
+
 def test_gateway_initialization_has_no_file_side_effect(clean_gateway):
     assert not clean_gateway.state_path.exists()
 
@@ -656,7 +665,7 @@ async def test_completion_applies_default_request_timeout(
 
     await clean_gateway.request_completion({"model": "ollama/llm"})
 
-    assert completion.call_args.kwargs["timeout"] == 600.0
+    assert completion.call_args.kwargs["timeout"] == 3600.0
 
 
 @pytest.mark.asyncio

--- a/tests/utils/test_structured_output.py
+++ b/tests/utils/test_structured_output.py
@@ -36,6 +36,23 @@ def test_json_schema_response_format_is_strict():
     assert result["json_schema"]["schema"] is SCHEMA
 
 
+def test_timeout_errors_are_not_retryable():
+    from lib.services_gateway import GatewayTimeoutError
+    from lib.structured_output import (
+        is_llm_timeout,
+        is_retryable_structured_error,
+    )
+
+    timeout = GatewayTimeoutError("Timed out after 3600s waiting for llm")
+    schema_error = ValueError("LLM response does not match the schema at $.status")
+
+    assert is_llm_timeout(timeout)
+    assert is_llm_timeout(TimeoutError("request timeout"))
+    assert not is_retryable_structured_error(timeout)
+    assert not is_retryable_structured_error(RuntimeError("provider unavailable"))
+    assert is_retryable_structured_error(schema_error)
+
+
 def test_schema_prompt_block_distinguishes_response_from_schema():
     prompt = schema_prompt_block(SCHEMA)
 


### PR DESCRIPTION
### Summary
- Structured Ollama calls disable thinking, send the schema through Ollama's native format field, and cap decode length so local Qwen models return JSON instead of <think> wrappers or unbounded generation.
- Timeouts are no longer retried as schema errors. Free-form completions still honor LLM_REQUEST_TIMEOUT (default 3600s); structured calls use a 180s ceiling. Gateway leases now outlive the longest HTTP timeout so a still-running call cannot lose its slot.
- Timed-out audit checks are recorded as check-level errors instead of stalling a due-diligence chapter for up to three hours.
### Test plan
- `conda run -n sictic-env python -m pytest -q --ignore=tests/live`
- Run one structured skill (e.g. a single batch_audit check) against a local Ollama Qwen model and confirm JSON returns in well under a few minutes
- Confirm a forced timeout is recorded once and is not retried
- For a 27B local model, set OLLAMA_NUM_PARALLEL=1 or 2 before a longer due-diligence run