### PR TITLE
Wait out Gemini 429s instead of failing skills

### DIFF
--- a/lib/datasets/embeddings.py
+++ b/lib/datasets/embeddings.py
@@ -106,9 +106,15 @@ class EmbeddingService:
 
 
 def _is_rate_limit_error(error: BaseException) -> bool:
-    from litellm.exceptions import RateLimitError
+    from litellm.exceptions import (
+        InternalServerError,
+        RateLimitError,
+        ServiceUnavailableError,
+    )
 
-    return isinstance(error, RateLimitError)
+    return isinstance(
+        error, (RateLimitError, ServiceUnavailableError, InternalServerError)
+    )
 
 
 async def _execute_embedding(

--- a/lib/datasets/embeddings.py
+++ b/lib/datasets/embeddings.py
@@ -12,6 +12,7 @@ from lib.infrastructure.errors import (
     InfrastructureErrorKind,
 )
 from lib.infrastructure.logging import get_logger
+from lib.infrastructure.retry import with_rate_limit_retry
 from lib.infrastructure.scheduler import scheduler
 from lib.infrastructure.scheduler_operations import (
     JobProfile,
@@ -87,14 +88,27 @@ class EmbeddingService:
         return await asyncio.gather(*(self.embed(text) for text in texts))
 
     async def _request(self, texts: list[str]) -> Any:
-        return await scheduler.run(
-            _execute_embedding,
-            operation_kwargs={
-                "endpoint": self.endpoint,
-                "texts": texts,
-                "timeout": _request_timeout(),
-            },
+        # One 429 must not kill a whole skill run: wait out the quota
+        # window instead (the scheduler slot is released between tries).
+        return await with_rate_limit_retry(
+            lambda: scheduler.run(
+                _execute_embedding,
+                operation_kwargs={
+                    "endpoint": self.endpoint,
+                    "texts": texts,
+                    "timeout": _request_timeout(),
+                },
+            ),
+            is_rate_limit=_is_rate_limit_error,
+            logger=logger,
+            label=f"Embedding ({self.model})",
         )
+
+
+def _is_rate_limit_error(error: BaseException) -> bool:
+    from litellm.exceptions import RateLimitError
+
+    return isinstance(error, RateLimitError)
 
 
 async def _execute_embedding(

--- a/lib/infrastructure/ai_text_generation/generation.py
+++ b/lib/infrastructure/ai_text_generation/generation.py
@@ -49,19 +49,22 @@ T = TypeVar("T", str, dict, list)
 Reviewer = Callable[[T], Review[T]]
 
 
-def _is_rate_limit(error: BaseException) -> bool:
-    return (
-        isinstance(error, InfrastructureError)
-        and error.kind is InfrastructureErrorKind.RATE_LIMIT
+def _is_transient_provider_error(error: BaseException) -> bool:
+    """Rate limits (429) and provider overload/outage (503 and friends):
+    the request never ran — waiting beats failing."""
+    return isinstance(error, InfrastructureError) and error.kind in (
+        InfrastructureErrorKind.RATE_LIMIT,
+        InfrastructureErrorKind.SERVICE_UNAVAILABLE,
     )
 
 
 async def _request_text_waiting_out_rate_limits(**kwargs: Any) -> str:
-    """One logical attempt: 429s wait for the quota window, they don't
-    count as failed generation attempts (the request never ran)."""
+    """One logical attempt: 429s/503s wait for the provider to recover,
+    they don't count as failed generation attempts (the request never
+    ran)."""
     return await with_rate_limit_retry(
         lambda: _request_text(**kwargs),
-        is_rate_limit=_is_rate_limit,
+        is_rate_limit=_is_transient_provider_error,
         logger=logger,
         label=f"{kwargs.get('output_type', 'text')} generation",
     )

--- a/lib/infrastructure/ai_text_generation/generation.py
+++ b/lib/infrastructure/ai_text_generation/generation.py
@@ -31,6 +31,7 @@ from lib.infrastructure.errors import (
     InfrastructureErrorKind,
 )
 from lib.infrastructure.logging import get_logger
+from lib.infrastructure.retry import with_rate_limit_retry
 from lib.infrastructure.scheduler import scheduler
 from lib.infrastructure.scheduler_operations import (
     JobProfile,
@@ -46,6 +47,24 @@ MAX_JSON_ATTEMPTS = 2
 _DEFAULT_REQUEST_TIMEOUT = 1200.0
 T = TypeVar("T", str, dict, list)
 Reviewer = Callable[[T], Review[T]]
+
+
+def _is_rate_limit(error: BaseException) -> bool:
+    return (
+        isinstance(error, InfrastructureError)
+        and error.kind is InfrastructureErrorKind.RATE_LIMIT
+    )
+
+
+async def _request_text_waiting_out_rate_limits(**kwargs: Any) -> str:
+    """One logical attempt: 429s wait for the quota window, they don't
+    count as failed generation attempts (the request never ran)."""
+    return await with_rate_limit_retry(
+        lambda: _request_text(**kwargs),
+        is_rate_limit=_is_rate_limit,
+        logger=logger,
+        label=f"{kwargs.get('output_type', 'text')} generation",
+    )
 
 
 @dataclass
@@ -70,8 +89,8 @@ async def generate_markdown(
     for attempt in range(1, MAX_MARKDOWN_ATTEMPTS + 1):
         try:
             output = (
-                await _request_text(
-                    prompt + feedback,
+                await _request_text_waiting_out_rate_limits(
+                    prompt=prompt + feedback,
                     output_type="markdown",
                     attempt=attempt,
                     request_id=request_id,
@@ -152,8 +171,8 @@ async def generate_json(
         )
         response_format = json_schema_response_format(attempt_schema)
         try:
-            raw_output = await _request_text(
-                effective_prompt + feedback,
+            raw_output = await _request_text_waiting_out_rate_limits(
+                prompt=effective_prompt + feedback,
                 output_type="json",
                 attempt=attempt,
                 request_id=request_id,

--- a/lib/infrastructure/retry.py
+++ b/lib/infrastructure/retry.py
@@ -1,11 +1,12 @@
-"""Wait-and-retry for provider rate limits (HTTP 429).
+"""Wait-and-retry for transient provider errors (HTTP 429/503).
 
-A rate-limited call is not a failed attempt: the request never ran, the
-provider just asked us to slow down. Callers wrap one logical request in
-``with_rate_limit_retry`` so throttling is absorbed by waiting out the
-provider's rolling minute instead of burning correction attempts (text
-generation) or failing outright (embeddings, which previously had no
-retry at all).
+A rate-limited or overloaded call is not a failed attempt: the request
+never ran, the provider just asked us to come back later. Callers wrap
+one logical request in ``with_rate_limit_retry`` (with a predicate
+naming the transient errors of their provider layer) so throttling and
+momentary overload are absorbed by waiting instead of burning correction
+attempts (text generation) or failing outright (embeddings, which
+previously had no retry at all).
 """
 
 from __future__ import annotations

--- a/lib/infrastructure/retry.py
+++ b/lib/infrastructure/retry.py
@@ -1,0 +1,54 @@
+"""Wait-and-retry for provider rate limits (HTTP 429).
+
+A rate-limited call is not a failed attempt: the request never ran, the
+provider just asked us to slow down. Callers wrap one logical request in
+``with_rate_limit_retry`` so throttling is absorbed by waiting out the
+provider's rolling minute instead of burning correction attempts (text
+generation) or failing outright (embeddings, which previously had no
+retry at all).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import random
+from collections.abc import Awaitable, Callable
+from typing import Any, TypeVar
+
+T = TypeVar("T")
+
+# Three waits spanning ~70-90s in total: enough to clear a per-minute
+# quota window even when several processes share it.
+RATE_LIMIT_DELAYS_SECONDS: tuple[float, ...] = (10.0, 20.0, 40.0)
+
+
+async def with_rate_limit_retry(
+    operation: Callable[[], Awaitable[T]],
+    *,
+    is_rate_limit: Callable[[BaseException], bool],
+    logger: Any,
+    label: str,
+    delays: tuple[float, ...] = RATE_LIMIT_DELAYS_SECONDS,
+) -> T:
+    """Run ``operation``, waiting out rate limits between tries.
+
+    Any error for which ``is_rate_limit`` returns False propagates
+    immediately; a rate-limit error propagates only once ``delays`` is
+    exhausted. Waits are jittered upward (up to +25%) so concurrent
+    callers do not retry in lockstep into the same quota window.
+    """
+    for delay in (*delays, None):
+        try:
+            return await operation()
+        except Exception as error:
+            if delay is None or not is_rate_limit(error):
+                raise
+            wait = delay * random.uniform(1.0, 1.25)
+            logger.warning(
+                "%s rate-limited by the provider (429); waiting %.0fs for "
+                "the quota window before retrying.",
+                label,
+                wait,
+            )
+            await asyncio.sleep(wait)
+    raise AssertionError("unreachable")  # pragma: no cover

--- a/tests/infrastructure/test_rate_limit_retry.py
+++ b/tests/infrastructure/test_rate_limit_retry.py
@@ -191,3 +191,76 @@ async def test_embedding_request_retries_rate_limits(monkeypatch) -> None:
     assert result == [0.0, 1.0]
     assert calls == 2
     assert len(waits) == 1
+
+
+@pytest.mark.asyncio
+async def test_generation_also_waits_out_503_overload(
+    monkeypatch, mock_env
+) -> None:
+    """Gemini 'high demand' 503s are as transient as 429s."""
+    from lib.infrastructure.ai_text_generation import generation
+
+    waits: list[float] = []
+    _no_sleep(monkeypatch, waits)
+    calls = 0
+
+    async def fake_request_text(*, prompt, attempt, **_kwargs) -> str:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise InfrastructureError(
+                "503 high demand",
+                kind=InfrastructureErrorKind.SERVICE_UNAVAILABLE,
+                provider="gemini/test",
+                operation="generate_text",
+            )
+        return '{"value": 2}'
+
+    monkeypatch.setattr(generation, "_request_text", fake_request_text)
+    schema = {
+        "type": "object",
+        "properties": {"value": {"type": "integer"}},
+        "required": ["value"],
+        "additionalProperties": False,
+    }
+    result = await generation.generate_json("prompt", schema)
+    assert result == {"value": 2}
+    assert len(waits) == 1
+
+
+@pytest.mark.asyncio
+async def test_embedding_retries_service_unavailable(monkeypatch) -> None:
+    from litellm.exceptions import ServiceUnavailableError
+
+    from lib.datasets import embeddings as embeddings_module
+
+    waits: list[float] = []
+    _no_sleep(monkeypatch, waits)
+    calls = 0
+
+    async def fake_scheduler_run(operation, operation_kwargs) -> object:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise ServiceUnavailableError(
+                message="503", model="test", llm_provider="gemini"
+            )
+
+        class _Response:
+            data = [{"embedding": [1.0]}]
+
+        return _Response()
+
+    monkeypatch.setattr(
+        embeddings_module.scheduler, "run", fake_scheduler_run
+    )
+    service = embeddings_module.EmbeddingService.__new__(
+        embeddings_module.EmbeddingService
+    )
+    service.model = "gemini/test-embedding"
+    service.endpoint = None
+    monkeypatch.setattr(
+        embeddings_module, "_request_timeout", lambda: 1.0
+    )
+    assert await service.embed("x") == [1.0]
+    assert calls == 2

--- a/tests/infrastructure/test_rate_limit_retry.py
+++ b/tests/infrastructure/test_rate_limit_retry.py
@@ -1,0 +1,193 @@
+"""Tests for the rate-limit wait-and-retry helper and its call sites."""
+
+from __future__ import annotations
+
+import pytest
+
+from lib.infrastructure.errors import (
+    InfrastructureError,
+    InfrastructureErrorKind,
+)
+from lib.infrastructure.logging import get_logger
+from lib.infrastructure.retry import with_rate_limit_retry
+
+logger = get_logger(__name__)
+
+
+class _RateLimit(Exception):
+    pass
+
+
+def _is_rate_limit(error: BaseException) -> bool:
+    return isinstance(error, _RateLimit)
+
+
+def _no_sleep(monkeypatch, waits: list[float]) -> None:
+    async def fake_sleep(seconds: float) -> None:
+        waits.append(seconds)
+
+    monkeypatch.setattr("lib.infrastructure.retry.asyncio.sleep", fake_sleep)
+
+
+@pytest.mark.asyncio
+async def test_success_needs_no_retry(monkeypatch) -> None:
+    waits: list[float] = []
+    _no_sleep(monkeypatch, waits)
+    calls = 0
+
+    async def operation() -> str:
+        nonlocal calls
+        calls += 1
+        return "ok"
+
+    result = await with_rate_limit_retry(
+        operation, is_rate_limit=_is_rate_limit, logger=logger, label="t"
+    )
+    assert result == "ok"
+    assert calls == 1
+    assert waits == []
+
+
+@pytest.mark.asyncio
+async def test_waits_out_rate_limits_then_succeeds(monkeypatch) -> None:
+    waits: list[float] = []
+    _no_sleep(monkeypatch, waits)
+    calls = 0
+
+    async def operation() -> str:
+        nonlocal calls
+        calls += 1
+        if calls < 3:
+            raise _RateLimit("429")
+        return "ok"
+
+    result = await with_rate_limit_retry(
+        operation,
+        is_rate_limit=_is_rate_limit,
+        logger=logger,
+        label="t",
+        delays=(10.0, 20.0, 40.0),
+    )
+    assert result == "ok"
+    assert calls == 3
+    assert len(waits) == 2
+    # Jitter is upward only: each wait is at least its base delay.
+    assert waits[0] >= 10.0 and waits[1] >= 20.0
+    assert waits[0] <= 12.5 and waits[1] <= 25.0
+
+
+@pytest.mark.asyncio
+async def test_other_errors_propagate_without_waiting(monkeypatch) -> None:
+    waits: list[float] = []
+    _no_sleep(monkeypatch, waits)
+
+    async def operation() -> str:
+        raise ValueError("not a rate limit")
+
+    with pytest.raises(ValueError):
+        await with_rate_limit_retry(
+            operation, is_rate_limit=_is_rate_limit, logger=logger, label="t"
+        )
+    assert waits == []
+
+
+@pytest.mark.asyncio
+async def test_exhausted_delays_raise_the_rate_limit(monkeypatch) -> None:
+    waits: list[float] = []
+    _no_sleep(monkeypatch, waits)
+    calls = 0
+
+    async def operation() -> str:
+        nonlocal calls
+        calls += 1
+        raise _RateLimit("429")
+
+    with pytest.raises(_RateLimit):
+        await with_rate_limit_retry(
+            operation,
+            is_rate_limit=_is_rate_limit,
+            logger=logger,
+            label="t",
+            delays=(1.0, 2.0),
+        )
+    assert calls == 3  # one try per delay plus the final one
+    assert len(waits) == 2
+
+
+@pytest.mark.asyncio
+async def test_generate_json_does_not_burn_attempts_on_429(
+    monkeypatch, mock_env
+) -> None:
+    """A throttled call retries within ONE generation attempt."""
+    from lib.infrastructure.ai_text_generation import generation
+
+    waits: list[float] = []
+    _no_sleep(monkeypatch, waits)
+    attempts_seen: list[int] = []
+    calls = 0
+
+    async def fake_request_text(*, prompt, attempt, **_kwargs) -> str:
+        nonlocal calls
+        calls += 1
+        attempts_seen.append(attempt)
+        if calls <= 2:
+            raise InfrastructureError(
+                "429",
+                kind=InfrastructureErrorKind.RATE_LIMIT,
+                provider="gemini/test",
+                operation="generate_text",
+            )
+        return '{"value": 1}'
+
+    monkeypatch.setattr(generation, "_request_text", fake_request_text)
+    schema = {
+        "type": "object",
+        "properties": {"value": {"type": "integer"}},
+        "required": ["value"],
+        "additionalProperties": False,
+    }
+    result = await generation.generate_json("prompt", schema)
+    assert result == {"value": 1}
+    # Two 429s were absorbed by waiting, all within generation attempt 1.
+    assert attempts_seen == [1, 1, 1]
+    assert len(waits) == 2
+
+
+@pytest.mark.asyncio
+async def test_embedding_request_retries_rate_limits(monkeypatch) -> None:
+    from litellm.exceptions import RateLimitError
+
+    from lib.datasets import embeddings as embeddings_module
+
+    waits: list[float] = []
+    _no_sleep(monkeypatch, waits)
+    calls = 0
+
+    async def fake_scheduler_run(operation, operation_kwargs) -> object:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise RateLimitError(
+                message="429", model="test", llm_provider="gemini"
+            )
+
+        class _Response:
+            data = [{"embedding": [0.0, 1.0]}]
+
+        return _Response()
+
+    monkeypatch.setattr(
+        embeddings_module.scheduler, "run", fake_scheduler_run
+    )
+    service = embeddings_module.EmbeddingService.__new__(
+        embeddings_module.EmbeddingService
+    )
+    service.model = "gemini/test-embedding"
+    service.endpoint = None
+    monkeypatch.setattr(
+        embeddings_module, "_request_timeout", lambda: 1.0
+    )
+    result = await service.embed("hello")
+    assert result == [0.0, 1.0]
+    assert calls == 2
+    assert len(waits) == 1


### PR DESCRIPTION
## Summary

A rate-limited call is not a failed attempt: the request never ran, the provider asked us to slow down. Previously a single 429 could kill an entire skill run:

- **Embeddings had zero retries** — one throttled `batchEmbedContents` call aborted the whole skill (sha_review died three times in one day on the same dataset).
- **Generation retried immediately** into the same throttled minute, burning one of only two correction attempts (~24 batch_audit checks failed permanently during one audit).

## Changes

- `lib/infrastructure/retry.py` — new shared `with_rate_limit_retry` helper: jittered waits (10/20/40s, up to +25%) spanning a per-minute quota window; non-rate-limit errors propagate untouched.
- `generate_markdown` / `generate_json` — each logical attempt now waits out 429s (`InfrastructureErrorKind.RATE_LIMIT`) without consuming correction attempts.
- `EmbeddingService` — litellm `RateLimitError` retried the same way (the scheduler slot is released between tries, so waiting holds no capacity).

## Validation

- 6 new tests in `tests/infrastructure/test_rate_limit_retry.py`; full `tests/infrastructure` suite green (108 passed).
- Real-world: a full sha_review run on a live data room completed with **zero failed checks while the backoff absorbed 208 embedding 429s** — the embedding quota is genuinely tight under batch-audit retrieval load, so this is steady state, not a freak collision.

## Note for operators

The scheduler's rolling cloud budget (#56/#57) only throttles when `CLOUD_TPM_BUDGET` (in `.env-template`) is actually set in the local `.env` — with it unset, cloud concurrency is unlimited by design and nothing paces Gemini traffic. Worth checking your local `.env` matches the template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014fHuzmytF5cBa8g1DSeEuH