### PR TITLE
Fix installer hang on required prompts at end of input

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -473,13 +473,22 @@ ask_env() {
         else
             printf '%s: ' "$prompt"
         fi
-        IFS= read -r answer || answer=""
+        eof=0
+        IFS= read -r answer || eof=1
         if [ -z "$answer" ] && [ -n "$shown_default" ]; then
             answer="$shown_default"
         fi
         if [ -n "$answer" ] || [ "$required" -eq 0 ]; then
             env_set "$key" "$answer"
             break
+        fi
+        # No further input can arrive, so re-prompting would loop forever.
+        if [ "$eof" -eq 1 ]; then
+            echo >&2
+            echo "install.sh: $key is required, but stdin reached end of input." >&2
+            echo "Run the installer interactively, or use --non-interactive to keep" >&2
+            echo "the values already present in .env." >&2
+            exit 1
         fi
         echo "  $key is required."
     done

--- a/install.sh
+++ b/install.sh
@@ -539,7 +539,7 @@ if [ "$INTERACTIVE" -eq 1 ]; then
     ask_env "OLLAMA_CONTEXT_LENGTH_MAX" "Ollama maximum context length" "$(env_get OLLAMA_CONTEXT_LENGTH_MAX || true)" 1 0
     ask_env "OLLAMA_NUM_PARALLEL" "Ollama parallel request limit" "$(env_get OLLAMA_NUM_PARALLEL || true)" 1 0
     ask_env "OLLAMA_MAX_LOADED_MODELS" "Ollama max loaded models" "$(env_get OLLAMA_MAX_LOADED_MODELS || true)" 1 0
-    ask_env "CLOUD_TPM_BUDGET" "Cloud rolling token-per-minute budget" "$(env_get CLOUD_TPM_BUDGET || true)" 1000000 0
+    ask_env "CLOUD_TPM_BUDGET" "Cloud rolling token-per-minute budget" "1000000" 1 0
     ask_env "OLLAMA_KV_CACHE_TYPE" "Ollama KV cache type" "$(env_get OLLAMA_KV_CACHE_TYPE || true)" 0 0
     ask_env "OLLAMA_FLASH_ATTENTION" "Ollama flash attention flag" "$(env_get OLLAMA_FLASH_ATTENTION || true)" 0 0
     ask_env "GEMINI_API_KEY" "Gemini API key (blank if unused)" "$(env_get GEMINI_API_KEY || true)" 0 1

--- a/tests/scripts/test_install_env_prompts.py
+++ b/tests/scripts/test_install_env_prompts.py
@@ -1,0 +1,109 @@
+import re
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INSTALL_SH = REPO_ROOT / "install.sh"
+
+ASK_ENV_CALL = re.compile(
+    r'^\s*ask_env\s+"(?P<key>[A-Z0-9_]+)"\s+".*?"\s+(?P<default>.+?)\s+'
+    r'(?P<required>\S+)\s+(?P<secret>\S+)\s*$'
+)
+
+
+def _extract_function(source: str, name: str) -> str:
+    start = source.index(f"\n{name}() {{\n") + 1
+    end = source.index("\n}\n", start) + len("\n}\n")
+    return source[start:end]
+
+
+def _harness(tmp_path: Path) -> Path:
+    """Run install.sh's .env helpers on their own.
+
+    The prompt helpers sit in the middle of a script that also builds a conda
+    environment, so they are lifted out of the real file rather than copied:
+    the test then fails if install.sh drifts away from what it asserts.
+    """
+    source = INSTALL_SH.read_text(encoding="utf-8")
+    functions = "\n".join(
+        _extract_function(source, name) for name in ("env_get", "env_set", "ask_env")
+    )
+    script = tmp_path / "ask_env_harness.sh"
+    script.write_text(
+        "#!/bin/sh\n"
+        "set -eu\n"
+        'ENV_PATH="$1"\n'
+        f"{functions}\n"
+        'ask_env "$2" "prompt for $2" "$3" "$4" 0\n',
+        encoding="utf-8",
+    )
+    script.chmod(0o755)
+    return script
+
+
+def _run(script: Path, env_file: Path, key: str, default: str, required: str):
+    return subprocess.run(
+        [str(script), str(env_file), key, default, required],
+        check=False,
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+        timeout=30,
+    )
+
+
+def test_required_prompt_without_default_fails_instead_of_looping(tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text("EXISTING=value\n", encoding="utf-8")
+    script = _harness(tmp_path)
+
+    result = _run(script, env_file, "CLOUD_TPM_BUDGET", "", "1")
+
+    assert result.returncode != 0
+    assert "CLOUD_TPM_BUDGET is required" in result.stderr
+    assert "CLOUD_TPM_BUDGET" not in env_file.read_text(encoding="utf-8")
+
+
+def test_supplied_default_answers_a_required_prompt(tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text("EXISTING=value\n", encoding="utf-8")
+    script = _harness(tmp_path)
+
+    result = _run(script, env_file, "CLOUD_TPM_BUDGET", "1000000", "1")
+
+    assert result.returncode == 0, result.stderr
+    assert "CLOUD_TPM_BUDGET=1000000" in env_file.read_text(encoding="utf-8")
+
+
+def test_configured_value_survives_a_differing_default(tmp_path):
+    env_file = tmp_path / ".env"
+    env_file.write_text("CLOUD_TPM_BUDGET=250000\n", encoding="utf-8")
+    script = _harness(tmp_path)
+
+    result = _run(script, env_file, "CLOUD_TPM_BUDGET", "1000000", "1")
+
+    assert result.returncode == 0, result.stderr
+    assert "CLOUD_TPM_BUDGET=250000" in env_file.read_text(encoding="utf-8")
+
+
+def test_every_ask_env_call_passes_boolean_required_and_secret_flags():
+    """Guard the argument order of ask_env(key, prompt, default, required, secret).
+
+    A default written into the `required` slot leaves the key required with no
+    fallback value, which is how the CLOUD_TPM_BUDGET prompt could never be
+    satisfied.
+    """
+    calls = []
+    for line in INSTALL_SH.read_text(encoding="utf-8").splitlines():
+        if not line.strip().startswith("ask_env "):
+            continue
+        match = ASK_ENV_CALL.match(line)
+        assert match, f"unparsed ask_env call: {line.strip()}"
+        calls.append(match)
+
+    assert calls, "no ask_env calls found in install.sh"
+    for match in calls:
+        key = match.group("key")
+        assert match.group("required") in {"0", "1"}, f"{key}: required must be 0 or 1"
+        assert match.group("secret") in {"0", "1"}, f"{key}: secret must be 0 or 1"


### PR DESCRIPTION
## Summary

A non-interactive `./install.sh --skip-env` run stalled for two hours at 100% CPU, producing no visible output. It was not slow work — it was `ask_env` re-prompting forever.

Two defects, one symptom:

1. **`CLOUD_TPM_BUDGET` was mis-specified.** `ask_env` takes `(key, prompt, default, required, secret)`, but the call passed the intended default `1000000` into the **`required`** slot and left the default empty. On any machine whose `.env` predates the rolling-budget change, the key was therefore required with no fallback value.
2. **The prompt loop could not fail.** `IFS= read -r answer || answer=""` discards the distinction between *empty input* and *no more input*. At end of stdin the loop re-prompted immediately, forever — spinning a core and writing `CLOUD_TPM_BUDGET is required.` into a buffer nobody sees once the installer is piped or run from CI.

Interactively you would never notice: you type a number and move on.

## Changes

- `install.sh` — pass `1000000` as the default with `required=1`, matching the `LOCAL_STORAGE_PATH` convention. An existing `.env` value still wins, since `ask_env` prefers `env_get` over the supplied default.
- `install.sh` — detect end of input in the prompt loop and exit with an explanatory message pointing at `--non-interactive`. Any future mis-specified prompt now fails immediately and legibly instead of hanging.
- `tests/scripts/test_install_env_prompts.py` — 4 tests: the EOF path exits rather than looping, a supplied default answers a required prompt, a configured value survives a differing default, and every `ask_env` call passes boolean flags in the `required`/`secret` positions.

The tests lift `env_get`, `env_set` and `ask_env` out of the real `install.sh` rather than copying them, so they fail if the script drifts away from what they assert.

## Validation

- Full suite green: **839 passed, 3 skipped** (`--ignore=tests/live`).
- Both fixes verified against a deliberately reverted copy: the loop test fails by timeout (reproducing the hang) and the argument-order test fails on the call line. Restored, all 4 pass.
- End-to-end: `./install.sh --rebuild-env --non-interactive` completed on Ubuntu 26.04 / WSL2, rebuilding the env on Python 3.13.15 with the suite green afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtVSH3PvpTqVyAs7aznTBn
