### PR TITLE
Standardize skill parameters and improve invitation cache reuse

### DIFF
--- a/config/deep_dive_invitation/email_template.md
+++ b/config/deep_dive_invitation/email_template.md
@@ -1,10 +1,7 @@
 Dear Founders, Investors and Industry Experts,
 
-Thank you for a great presentation at the SICTIC Investor Day! Because of the strong interest, we are moving straight to the deep-dive phase.
+@Founder(s): Thank you for a great presentation at the SICTIC Investor Day! We are happy to announce that you have investors who marked interest in your startup. We kindly ask you to schedule a Deep Dive call with the interested investors within the next two weeks by providing Doodle details (or similar) to all interested investors to find a date that works for most.
 
-Please organize a **1-hour Deep Dive video conference** within the next **two weeks** with the interested investors listed below.
-
-- **To Schedule:** Send a scheduling link (e.g., Calendly, Doodle) by replying to this email.
 - **Investors to Invite:**
 
 {{investor_table}}
@@ -13,12 +10,16 @@ Please organize a **1-hour Deep Dive video conference** within the next **two we
   - [SICTIC Deep Dive Template](https://docs.google.com/document/d/19NTunN9mGohtjwcG5OoKiUlMhkc80bKvlYv9F695Oe4/edit?usp=sharing) (Call structure)
   - [SICTIC Due Diligence Checklist](https://docs.google.com/document/d/13VKzojeHreU6_OThlw8k4uJrXi4bjyKyqEXsPE3t_JU/edit#heading=h.phrycr62ikcy) (Data room prep)
   - [SECA Legal Templates](https://www.seca.ch/Templates/Templates/VC-Model-Documentation/VC-Model-Documentation-light.aspx) (Term sheets & SHA)
+  - [Structure of Deep Dive / Due Diligence process](https://drive.google.com/file/d/1LRXe68NGjd65OdfPuZX7jvgrKcOsS64c/view?usp=sharing)
+  - [FAQ Sheet](https://docs.google.com/document/d/1CYci-y0xzEMmHmPRkx-d3AjUYWUlb4ZjvdnNFxpgtGc/edit?usp=sharing)
 
-Domain experts who might find this opportunity relevant are on BCC.
+@Investors: Please step forward if you would like to be Lead Investor. If you are new / need support but would like to try the role, please reach out to us at info@sictic.ch and we will gladly support you through the process. Same applies if multiple of you are interested in a syndicate and need support with that.
 
-- **View Startup Profile:** [Dealum application]({{dealum_url}})
-- **To Join the Deep Dive:** Express your interest under the funding header in Dealum.
-- **Manage Alert Preferences:** Update your settings via this [Feedback Form](https://forms.gle/wEkEBbHsje7DDKPC8).
+We also kindly ask you to keep Dealum up to date with your investor interest and when you close the round, so we can keep track.
+
+@Industry Experts on BCC: This opportunity may be relevant for you. You can find more information here: [Dealum application]({{dealum_url}}). Also express your interest there as well. You can manage your notification preferences here [Feedback Form](https://forms.gle/wEkEBbHsje7DDKPC8).
+
+If you have any questions, you can reach us at info@sictic.ch.
 
 Best regards,
 

--- a/config/deep_dive_invitation/settings.json
+++ b/config/deep_dive_invitation/settings.json
@@ -3,5 +3,5 @@
   "max_experts": 10,
   "expert_search_candidates": 16,
   "preference_key": "deep_dive_invitation",
-  "output_format_version": 5
+  "output_format_version": 6
 }

--- a/lib/insights/file.py
+++ b/lib/insights/file.py
@@ -285,8 +285,8 @@ class InsightFile:
             _path_override=f"{self.directory}/{filename}",
         )
 
-    def _dataset_revisions(self) -> dict[str, str] | None:
-        return dataset_revisions(get_storage(), self.source_datasets)
+    def _dataset_revisions(self, *, missing: list[str] | None = None) -> dict[str, str] | None:
+        return dataset_revisions(get_storage(), self.source_datasets, missing=missing)
 
     def _load_manifest(self) -> dict:
         return load_insight_manifest(get_storage(), self._manifest_path)

--- a/lib/insights/manifest.py
+++ b/lib/insights/manifest.py
@@ -23,12 +23,16 @@ def config_hash(config_key: str) -> str:
 def dataset_revisions(
     storage,
     source_datasets: list[str],
+    *,
+    missing: list[str] | None = None,
 ) -> dict[str, str] | None:
     revisions = {}
     for name in sorted(set(source_datasets)):
         location = dataset_location(name)
         manifest = IngestionManifest.load(storage, location.parsed_rel)
         if not manifest.indexed_dataset_revision:
+            if missing is not None:
+                missing.append(location.slug)
             return None
         revisions[location.slug] = manifest.indexed_dataset_revision
     return revisions

--- a/lib/insights/selection.py
+++ b/lib/insights/selection.py
@@ -35,21 +35,29 @@ def find(insight, *, selection: InsightSelection):
 
 
 def _find_reusable(insight):
+    context = f"{insight.dataset}/{insight.skill}"
     manual = insight._candidate("manual")
     if manual.exists():
-        logger.info("Using manual insight: %s", manual.path)
+        logger.info("[%s] Reusing manual version: %s", context, manual.path)
         return manual
 
     manifest = insight._load_manifest()
-    expected_revisions = insight._dataset_revisions()
+    missing_revisions: list[str] = []
+    expected_revisions = insight._dataset_revisions(missing=missing_revisions)
     if expected_revisions is None:
+        logger.info(
+            "[%s] Cache miss: indexed revision missing: %s",
+            context, ", ".join(missing_revisions),
+        )
         return None
     expected_config_hash = config_hash(insight.config_key)
 
+    found_candidate = False
     for model, ranked_model_slug in ranked_models():
         candidate = insight._candidate(model)
         if not candidate.exists():
             continue
+        found_candidate = True
         entry = manifest["entries"].get(candidate.path)
         if (
             isinstance(entry, dict)
@@ -57,9 +65,42 @@ def _find_reusable(insight):
             and entry.get("dataset_revisions") == expected_revisions
             and _stored_config_hash(entry) == expected_config_hash
         ):
-            logger.info("Using reusable insight: %s", candidate.path)
+            logger.info(
+                "[%s] Reusing generated version (%s): %s",
+                context, ranked_model_slug, candidate.path,
+            )
             return candidate
+        reasons = _rejection_reasons(entry, ranked_model_slug, expected_revisions, expected_config_hash)
+        logger.info(
+            "[%s] Cache miss (%s): %s [file: %s]",
+            context, ranked_model_slug, "; ".join(reasons), candidate.path,
+        )
+    if not found_candidate:
+        logger.info("[%s] Cache miss: no existing candidate files", context)
     return None
+
+
+def _rejection_reasons(entry, model, revisions, configuration_hash) -> list[str]:
+    """Describe a rejected candidate without logging prompt or contact content."""
+    if not isinstance(entry, dict):
+        return ["freshness metadata missing"]
+    reasons = []
+    stored_revisions = entry.get("dataset_revisions")
+    stored_hash = _stored_config_hash(entry)
+    if not entry.get("model") or not isinstance(stored_revisions, dict) or not stored_hash:
+        reasons.append("freshness metadata missing or invalid")
+    if entry.get("model") and entry["model"] != model:
+        reasons.append("stored model mismatch")
+    if isinstance(stored_revisions, dict):
+        changed = sorted(
+            name for name in set(stored_revisions) | set(revisions)
+            if stored_revisions.get(name) != revisions.get(name)
+        )
+        if changed:
+            reasons.append(f"dataset changed: {', '.join(changed)}")
+    if stored_hash and stored_hash != configuration_hash:
+        reasons.append("prompt/configuration/inputs changed")
+    return reasons
 
 
 def is_reusable(insight) -> bool:

--- a/skills/dataset_chat/SKILL.md
+++ b/skills/dataset_chat/SKILL.md
@@ -55,6 +55,10 @@ The direct CLI has `search`, `chat` and `sync` commands. Its retained
 Direct search uses the search API's default error policy; generated answers
 use strict retrieval errors.
 
+Direct `search` and `chat` take one positional `DATASET`; `chat` takes one
+`QUESTION`. Direct `sync` takes space-separated `DATASETS...`, while harness
+`/sync` takes one positional `dataset`.
+
 ## References
 
 - [Implementation](dataset_chat.py), [direct CLI](__main__.py)

--- a/skills/dataset_chat/__main__.py
+++ b/skills/dataset_chat/__main__.py
@@ -13,7 +13,7 @@ app = typer.Typer(help="High-precision Dataset Chat and RAG Engine.")
 
 @app.command("search")
 def search_cmd(
-    dataset_name: str = typer.Argument(..., help="Name of the dataset/collection to search."),
+    dataset_name: str = typer.Argument(..., metavar="DATASET", help="Name of the dataset/collection to search."),
     query: str = typer.Argument("", help="The query/question to search for.")
 ):
     chunks = run_command(
@@ -33,8 +33,8 @@ def search_cmd(
 
 @app.command("chat")
 def chat_cmd(
-    dataset_name: str = typer.Argument(..., help="Name of the dataset/collection to chat with."),
-    questions: str = typer.Argument(..., help="The query/question to ask."),
+    dataset_name: str = typer.Argument(..., metavar="DATASET", help="Name of the dataset/collection to chat with."),
+    questions: str = typer.Argument(..., metavar="QUESTION", help="The query/question to ask."),
     llm_instructions: Optional[str] = typer.Argument(None, help="Optional formatting/anti-hallucination instructions.")
 ):
     response = run_command(
@@ -55,7 +55,7 @@ def chat_cmd(
 
 @app.command("sync")
 def sync_cmd(
-    dataset_names: List[str] = typer.Argument(..., help="Names of the datasets/collections to sync. Can pass multiple separated by spaces."),
+    dataset_names: List[str] = typer.Argument(..., metavar="DATASETS...", help="Names of the datasets/collections to sync. Can pass multiple separated by spaces."),
     force: bool = typer.Option(False, "--force", help="Bypass the short in-process sync cache.")
 ):
     run_command(

--- a/skills/dataset_maintenance/SKILL.md
+++ b/skills/dataset_maintenance/SKILL.md
@@ -16,7 +16,7 @@ Operate on dataset indexes and storage through the existing shared abstractions.
 | `delete --dataset D` | Immediately delete D's tenant across shared model collections **and its parsed directory**. Raw sources and insights remain. |
 | `delete --dataset D --embeddings M` | Immediately delete one tenant/model and reset matching index metadata; preserve parsed files. |
 | `delete --embeddings M` | Immediately delete the entire shared model collection and reset affected dataset manifests. |
-| `rebuild-index --dataset D` | Reset that tenant for the configured embedding model, preserving parsing checkpoints; then synchronize by default. `--no-sync` stops after reset. |
+| `rebuild-index --datasets D` | Reset that tenant for the configured embedding model, preserving parsing checkpoints; then synchronize by default. `--no-sync` stops after reset. |
 | `activate` / `archive` | Set/remove refresh eligibility markers; do not delete the dataset. |
 | `create` | Create the standard startup dossier and activate it. |
 | `dataset-from-insight` | Reconcile selected insights into a generated dataset; can remove obsolete target files. Writes by default; `--dry-run` previews. Does not index. |
@@ -37,12 +37,18 @@ it does not establish equivalence with every current skill cache key.
 ```bash
 conda run -n sictic-env python -m skills.dataset_maintenance diagnose
 conda run -n sictic-env python -m skills.dataset_maintenance prune
-conda run -n sictic-env python -m skills.dataset_maintenance rebuild-index --dataset example-startup --no-sync
+conda run -n sictic-env python -m skills.dataset_maintenance rebuild-index --datasets example-startup --no-sync
 conda run -n sictic-env python -m skills.dataset_maintenance dataset-from-insight --target-dataset example-generated --skill person_profile --dry-run
 ```
 
 These operations are not harness or bulk-refresh jobs. Use command `--help`
 for selectors; `delete` has no dry-run flag.
+
+`rebuild-index`, `activate` and `archive` accept comma-separated `--datasets`,
+with `--dataset` retained as a compatibility alias. `delete --dataset` selects
+one dataset. `create STARTUP` accepts one positional startup.
+`dataset-from-insight` uses one `--target-dataset` and comma-separated
+`--source-datasets`; its older `--source-dataset` alias remains supported.
 
 ## References
 

--- a/skills/dataset_maintenance/__main__.py
+++ b/skills/dataset_maintenance/__main__.py
@@ -79,7 +79,7 @@ def delete_command(
 
 @app.command("rebuild-index")
 def rebuild_index_command(
-    dataset: str = typer.Option(..., "--dataset", "-d"),
+    dataset: str = typer.Option(..., "--datasets", "--dataset", "-d", help="Comma-separated datasets."),
     sync: bool = typer.Option(
         True,
         "--sync/--no-sync",
@@ -118,7 +118,7 @@ def rebuild_index_command(
 
 @app.command("activate")
 def activate_command(
-    dataset: str = typer.Option(..., "--dataset", "-d"),
+    dataset: str = typer.Option(..., "--datasets", "--dataset", "-d", help="Comma-separated datasets."),
 ) -> None:
     slugs = run_command(
         lambda: [activate_dataset_marker(item) for item in _parse_datasets(dataset)],
@@ -130,7 +130,7 @@ def activate_command(
 
 @app.command("archive")
 def archive_command(
-    dataset: str = typer.Option(..., "--dataset", "-d"),
+    dataset: str = typer.Option(..., "--datasets", "--dataset", "-d", help="Comma-separated datasets."),
 ) -> None:
     slugs = run_command(
         lambda: [archive_dataset_marker(item) for item in _parse_datasets(dataset)],
@@ -142,7 +142,7 @@ def archive_command(
 
 @app.command("create")
 def create_command(
-    startup_name: str = typer.Argument(..., help="Startup name for the new dossier."),
+    startup_name: str = typer.Argument(..., metavar="STARTUP", help="Startup name for the new dossier."),
 ) -> None:
     slug = run_command(
         lambda: ensure_startup_dossier(startup_name),

--- a/skills/dealum_import/SKILL.md
+++ b/skills/dealum_import/SKILL.md
@@ -33,7 +33,8 @@ conda run -n sictic-env python -m skills.harness '/dealum_import "<EXACT_NAME_OR
 conda run -n sictic-env python -m skills.dealum_import "Avientus, daav"
 ```
 
-Only the direct CLI splits a comma-separated startup list.
+The direct CLI's positional `STARTUPS` argument accepts a comma-separated list.
+The harness's positional `startup` accepts one name or code.
 This skill is not registered for bulk refresh; other workflows may invoke the
 shared, gated `ensure_startup_dataset` preparation separately.
 

--- a/skills/dealum_import/__main__.py
+++ b/skills/dealum_import/__main__.py
@@ -9,7 +9,7 @@ app = typer.Typer(help="Import a startup application and linked documents from D
 
 
 @app.command()
-def main(startup: str):
+def main(startup: str = typer.Argument(..., metavar="STARTUPS", help="Comma-separated startup names or codes.")):
     startups = [name.strip() for name in startup.split(",") if name.strip()]
     if not startups:
         raise typer.BadParameter("Provide at least one startup name.")

--- a/skills/deep_dive_invitation/SKILL.md
+++ b/skills/deep_dive_invitation/SKILL.md
@@ -21,7 +21,13 @@ contacts. Ask for the exact startup name/code only when unclear.
 
 ## Workflow and dependencies
 
-Import Dealum data, request normal `startup_profile`, read member preferences,
+Resolve the startup slug through shared startup identity and look for a reusable
+invitation before running dependencies. Manual invitations always win; generated
+invitations require matching indexed revisions for the startup and `sictic-members`,
+plus matching template/settings and supplied contacts. A cache hit returns immediately
+without importing, synchronizing, profiling, reading member preferences or ranking.
+
+On a cache miss, import Dealum data, request normal `startup_profile`, read member preferences,
 then request `expert_search`. Existing member rosters and investor profiles are
 required; the invitation does not discover people. It has no bulk registration.
 
@@ -35,15 +41,23 @@ not automated, so the draft always includes a verification notice.
 
 Interested investors with an address remain in Cc even with preference `none`;
 missing addresses create notices and are omitted until completed. Exclude interested
-members and opted-out members from expert search. Configuration currently requests
+members from Bcc selection after expert search; only preference opt-outs are
+passed as expert-search exclusions. Changing interested investors therefore does
+not change the ranking request. Match Cc recipients by existing member identity
+as well as email, so alternate addresses do not duplicate recipients across Cc
+and Bcc. Apply this filter before the Bcc limit. Configuration currently requests
 16 candidates and selects at most 10 usable experts. Bcc excludes addresses already
 in To/Cc; experts appear only in Bcc, not as named rows in the email body.
 
-Render the configured template mechanically after reconciliation. Cache lookup
-occurs after dependencies; its key includes configuration, supplied people,
-member preferences and expert-report content, with startup/community revisions.
-Resolved member contacts are not independently hashed, so contact edits alone
-may not invalidate the draft.
+Render the configured template mechanically after reconciliation. Cache freshness
+uses recorded indexed revisions, so unindexed source changes and direct edits to
+member preferences, stored contacts or expert reports do not independently invalidate
+the invitation. Dependency outputs are not included in its cache key. Generated
+drafts using the previous key are regenerated once; manual precedence is unchanged.
+
+For an application code that cannot resolve locally to the startup dataset,
+Dealum import must resolve the canonical slug first. Check the resolved dataset
+for a reusable invitation before executing the remaining dependencies.
 
 ## Side effects and failure behavior
 

--- a/skills/deep_dive_invitation/deep_dive_invitation.py
+++ b/skills/deep_dive_invitation/deep_dive_invitation.py
@@ -3,17 +3,18 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-import hashlib
 import json
 from pathlib import PurePosixPath
 import re
 
 from lib.infrastructure.configuration import config_cache_key, load_repository_config
 from lib.infrastructure.logging import get_logger
+from lib.datasets.paths import find_dataset_location
 from lib.insights import InsightFile, InsightResult
 from lib.model_config import llm_model
 from lib.people import Person, markdown_table_to_person_objects
 from lib.slugify import slugify
+from lib.startups.identity import canonical_startup_slug
 from lib.storage import get_storage
 from skills.dealum_import.dealum_import import dealum_import
 from skills.expert_search.expert_search import expert_search
@@ -230,22 +231,14 @@ def _founder_resolutions(
 
 
 def _expert_exclusions(
-    investor_resolutions: list[RecipientResolution],
     members: list[Person],
     preference_key: str,
-) -> tuple[list[str], list[str], list[str]]:
+) -> list[str]:
     preference_exclusions: list[str] = []
     for member in members:
         if preferences_for(member).get(preference_key, "standard") == "none":
             preference_exclusions.append(member.identifier)
-    investor_exclusions: list[str] = []
-    for resolution in investor_resolutions:
-        matches = _exact_member_matches(resolution.person, members)
-        investor_exclusions.extend(match.identifier for match in matches)
-    preference_exclusions = list(dict.fromkeys(preference_exclusions))
-    investor_exclusions = list(dict.fromkeys(investor_exclusions))
-    combined = list(dict.fromkeys(preference_exclusions + investor_exclusions))
-    return combined, preference_exclusions, investor_exclusions
+    return sorted(set(preference_exclusions))
 
 
 def _select_experts(
@@ -266,12 +259,20 @@ def _select_experts(
         for resolution in investor_resolutions
         if resolution.selected_email
     }
+    cc_member_ids = {
+        member.identifier
+        for resolution in investor_resolutions
+        if resolution.selected_email
+        for member in _exact_member_matches(resolution.person, members)
+    }
     selected: list[Person] = []
     for candidate in ranked:
         matches = _exact_member_matches(candidate, members)
         if len(matches) != 1:
             continue
         member = matches[0]
+        if member.identifier in cc_member_ids:
+            continue
         candidate.merge(member)
         if preferences_for(member).get(preference_key, "standard") == "none":
             continue
@@ -375,7 +376,31 @@ async def deep_dive_invitation(
     template = config["email_template"]
     settings = config["settings"]
 
+    startup_slug = canonical_startup_slug(startup)
+    cache_key = config_cache_key(
+        config,
+        [_person_snapshot(person) for person in supplied_founders],
+        [_person_snapshot(person) for person in supplied_investors],
+    )
+    insight = InsightFile(
+        dataset=startup_slug,
+        skill="deep_dive_invitation",
+        model=llm_model(),
+        source_datasets=[startup_slug, "sictic-members"],
+        config_key=cache_key,
+    )
+    if find_dataset_location(startup_slug) is not None:
+        if reusable := insight.find(selection="reusable"):
+            return [reusable]
+
     dealum = await dealum_import(startup)
+    # A Dealum application code can resolve to a different dataset slug.
+    # Check that dataset before running the remaining dependencies.
+    if dealum.dataset_slug != startup_slug:
+        insight.dataset = dealum.dataset_slug
+        insight.source_datasets = [dealum.dataset_slug, "sictic-members"]
+        if reusable := insight.find(selection="reusable"):
+            return [reusable]
     startup_slug = dealum.dataset_slug
     await startup_profile(startup_slug)
 
@@ -394,14 +419,13 @@ async def deep_dive_invitation(
     )
 
     preference_key = settings["preference_key"]
-    exclusions, preference_exclusions, investor_exclusions = _expert_exclusions(
-        investor_resolutions,
+    preference_exclusions = _expert_exclusions(
         members,
         preference_key,
     )
     [expert_insight] = await expert_search(
         startup_slug,
-        exclude_experts=exclusions,
+        exclude_experts=preference_exclusions,
         top_k=settings["expert_search_candidates"],
     )
     experts = _select_experts(
@@ -452,30 +476,6 @@ async def deep_dive_invitation(
     body = body.replace("{{investor_table}}", _investor_table(investor_resolutions))
     body = body.replace("{{dealum_url}}", dealum.dealum_url or "<insert Dealum link here>")
 
-    expert_digest = hashlib.sha256(expert_insight.content().encode()).hexdigest()
-    cache_key = config_cache_key(
-        config,
-        [_person_snapshot(person) for person in supplied_founders],
-        [_person_snapshot(person) for person in supplied_investors],
-        [
-            {
-                "identifier": member.identifier,
-                "preferences": preferences_for(member),
-            }
-            for member in members
-        ],
-        {"expert_insight": expert_insight.path, "content_sha256": expert_digest},
-    )
-    insight = InsightFile(
-        dataset=startup_slug,
-        skill="deep_dive_invitation",
-        model=llm_model(),
-        source_datasets=[startup_slug, "sictic-members"],
-        config_key=cache_key,
-    )
-    if reusable := insight.find(selection="reusable"):
-        return [reusable]
-
     content = "\n".join(
         [
             "# Review notices",
@@ -496,8 +496,7 @@ async def deep_dive_invitation(
             "",
             "- Member preference opt-outs excluded from expert search: "
             f"{len(preference_exclusions)}",
-            "- Interested members excluded from expert search: "
-            f"{len(investor_exclusions)}",
+            f"- Interested investors with an email in Cc: {len(cc_addresses)}",
             f"- Usable experts selected for Bcc: {len(bcc_addresses)}",
             "",
             "# Email draft",

--- a/skills/harness/SKILL.md
+++ b/skills/harness/SKILL.md
@@ -41,6 +41,11 @@ command when passing skill options separately, so the outer CLI does not consume
 them. A whole quoted command remains supported; retain inner double quotes around
 its multiword values. Interactive command text uses the same inner quoting.
 
+Parameter names follow the shared CLI naming rules. `/investor_profile` uses
+`--dataset` (legacy alias `--source-dataset`); `/suggested_startups` uses
+`--investors` (legacy alias `--investor`). Positional selectors remain supported:
+single-startup commands use `startup`, while `/submission_ready` takes `startups`.
+
 ## References
 
 - [Dispatcher and command registry](harness.py)

--- a/skills/harness/harness.py
+++ b/skills/harness/harness.py
@@ -150,7 +150,7 @@ async def _team_profile_revised(args: List[str]) -> str:
 
 async def _investor_profile(args: List[str]) -> str:
     parser = _parser("/investor_profile")
-    parser.add_argument("--source-dataset", default="sictic-members")
+    parser.add_argument("--dataset", "--source-dataset", "-d", dest="source_dataset", default="sictic-members")
     ns = parser.parse_args(args)
     from skills.investor_profile.investor_profile import investor_profile
 
@@ -218,7 +218,7 @@ async def _advocates(args: List[str]) -> str:
 async def _suggested_startups(args: List[str]) -> str:
     parser = _parser("/suggested_startups")
     parser.add_argument("--startups", "-s")
-    parser.add_argument("--investor", "-i")
+    parser.add_argument("--investors", "--investor", "-i", dest="investor")
     parser.add_argument("--max-startups", "-m", type=int, default=16)
     ns = parser.parse_args(args)
     from skills.suggested_startups.suggested_startups import suggested_startups
@@ -250,7 +250,7 @@ async def _dd_priorities(args: List[str]) -> str:
 
 async def _sha_review(args: List[str]) -> str:
     parser = _parser("/sha_review")
-    parser.add_argument("dataset")
+    parser.add_argument("dataset", metavar="startup")
     ns = parser.parse_args(args)
     from skills.sha_review.sha_review import sha_review
 
@@ -296,7 +296,7 @@ def build_registry() -> Dict[str, HarnessCommand]:
         HarnessCommand("/person_profile", "/person_profile <dataset> <person>", "Generate a person profile.", _person_profile),
         HarnessCommand("/team_profile", "/team_profile <startup>", "Generate a team profile.", _team_profile),
         HarnessCommand("/team_profile_revised", "/team_profile_revised <startup>", "Assess team checklists and synthesize each category.", _team_profile_revised),
-        HarnessCommand("/investor_profile", "/investor_profile [--source-dataset dataset]", "Build investor profiles.", _investor_profile),
+        HarnessCommand("/investor_profile", "/investor_profile [--dataset dataset]", "Build investor profiles.", _investor_profile),
         HarnessCommand("/expert_search", "/expert_search <startup>", "Rank relevant experts.", _expert_search),
         HarnessCommand("/potential_investors", "/potential_investors <startup>", "Rank potential investors.", _potential_investors),
         HarnessCommand(
@@ -312,16 +312,16 @@ def build_registry() -> Dict[str, HarnessCommand]:
             _deep_dive_invitation,
         ),
         HarnessCommand("/advocates", '/advocates <event> --description "..."', "Rank event advocates.", _advocates),
-        HarnessCommand("/suggested_startups", "/suggested_startups --startups a,b --investor x,y", "Suggest startups for investors.", _suggested_startups),
+        HarnessCommand("/suggested_startups", "/suggested_startups --startups a,b --investors x,y", "Suggest startups for investors.", _suggested_startups),
         HarnessCommand(
             "/submission_ready",
-            "/submission_ready [startup ...]",
+            "/submission_ready [startups ...]",
             "Check in-scope application completeness and eligibility.",
             _submission_ready,
         ),
         HarnessCommand("/dd_checks", "/dd_checks <startup>", "Run due-diligence checks.", _dd_checks),
         HarnessCommand("/dd_priorities", "/dd_priorities <startup>", "Prioritize an existing DD checks report.", _dd_priorities),
-        HarnessCommand("/sha_review", "/sha_review <dataset>", "Review a startup Shareholders' Agreement.", _sha_review),
+        HarnessCommand("/sha_review", "/sha_review <startup>", "Review a startup Shareholders' Agreement.", _sha_review),
         HarnessCommand("/dealum_import", "/dealum_import <startup>", "Import startup data from Dealum.", _dealum_import),
     ]
     return {cmd.name: cmd for cmd in commands}

--- a/skills/investor_profile/SKILL.md
+++ b/skills/investor_profile/SKILL.md
@@ -42,11 +42,13 @@ not a supported exception to that rule.
 ## Usage
 
 ```bash
-conda run -n sictic-env python -m skills.harness -- /investor_profile --source-dataset "<DATASET>"
+conda run -n sictic-env python -m skills.harness -- /investor_profile --dataset "<DATASET>"
 ```
 
-The direct CLI also accepts `--person "<NAME_1>, <NAME_2>"`; omission selects all
+The direct CLI also accepts `--persons "<NAME_1>, <NAME_2>"`; omission selects all
 eligible roster members. Both CLIs default to `sictic-members`.
+`--source-dataset` remains an alias for `--dataset`; the direct CLI retains
+`--person` as an alias for `--persons`.
 
 ## References
 

--- a/skills/investor_profile/__main__.py
+++ b/skills/investor_profile/__main__.py
@@ -11,11 +11,14 @@ app = typer.Typer(add_completion=False, help="Build investor profiles from perso
 def main(
     source_dataset: str = typer.Option(
         "sictic-members",
+        "--dataset",
         "--source-dataset",
+        "-d",
         help="Community dataset containing person profiles and track records.",
     ),
     person: str | None = typer.Option(
         None,
+        "--persons",
         "--person",
         "-p",
         help="Comma-separated person names; omit to build profiles for all members.",

--- a/skills/person_profile/SKILL.md
+++ b/skills/person_profile/SKILL.md
@@ -51,8 +51,10 @@ The harness requires a person; the direct CLI also supports the complete roster.
 ```bash
 conda run -n sictic-env python -m skills.harness /person_profile "<DATASET>" "<NAME>"
 conda run -n sictic-env python -m skills.person_profile --dataset "<DATASET>"
-conda run -n sictic-env python -m skills.person_profile --dataset "<DATASET>" --person "<NAME_1>, <NAME_2>"
+conda run -n sictic-env python -m skills.person_profile --dataset "<DATASET>" --persons "<NAME_1>, <NAME_2>"
 ```
+
+The direct CLI retains `--person` as an alias for `--persons`.
 
 ## References
 

--- a/skills/person_profile/__main__.py
+++ b/skills/person_profile/__main__.py
@@ -13,6 +13,7 @@ def main(
     dataset: str = typer.Option(..., "--dataset", "-d", help="The target dataset to search."),
     person: Optional[str] = typer.Option(
         None,
+        "--persons",
         "--person",
         "-p",
         help=(

--- a/skills/sha_review/SKILL.md
+++ b/skills/sha_review/SKILL.md
@@ -50,10 +50,10 @@ does not invalidate an existing synthesis. This automated review aids human revi
 ## Usage
 
 ```bash
-conda run -n sictic-env python -m skills.harness '/sha_review "<DATASET>"'
+conda run -n sictic-env python -m skills.harness '/sha_review "<STARTUP>"'
 ```
 
-The direct CLI uses `--dataset`.
+The direct CLI uses `--startup`; `--dataset` and `-d` remain compatibility aliases.
 
 ## References
 

--- a/skills/sha_review/__main__.py
+++ b/skills/sha_review/__main__.py
@@ -14,7 +14,9 @@ app = typer.Typer(
 def run_sha_review(
     dataset_name: str = typer.Option(
         ...,
+        "--startup",
         "--dataset",
+        "-s",
         "-d",
         help="Target startup dataset name.",
     ),

--- a/skills/standards_and_architecture/SKILL.md
+++ b/skills/standards_and_architecture/SKILL.md
@@ -182,6 +182,13 @@ this one.
 Missing indexed source revisions prevent verified reuse. Saving may
 still write the artifact without new freshness metadata.
 
+Reusable selection logs cache hits and misses at INFO level. Rejected candidates
+include the model, artifact path and all detected mismatch reasons. Dataset revision
+changes name the datasets; configuration, prompt and input changes share one reason
+without exposing their content. Missing files, freshness metadata and indexed
+revisions are distinguished. Revision lookup stops at the first missing revision
+and names that dataset. Logging does not change selection or freshness policy.
+
 Use `has_insufficient_context()` to recognize the exact
 `INSUFFICIENT_CONTEXT` sentinel; this is separate from freshness.
 
@@ -453,6 +460,20 @@ results. Explicit adapters may return domain objects while sharing
 the same underlying workflow.
 
 ### CLI and harness
+
+Name user-facing parameters by subject: `startup` for startup-specific workflows
+and `dataset` for workflows supporting general datasets. Use singular names for
+one input and plural names for selectors accepting multiple inputs, even when
+only one is supplied (`--startup` versus `--startups`, `--person` versus
+`--persons`). Use role prefixes only to distinguish inputs, such as
+`--source-datasets` and `--target-dataset` when both are present.
+
+Use the same names for the same subject and cardinality across skills, direct
+CLIs and the harness. Option names use lowercase hyphen-separated words without
+redundant `-name` suffixes; positional labels follow the same subject/cardinality
+rules. Existing positional syntax and list parsing remain supported. Older option
+spellings remain compatibility aliases; document and prefer canonical names.
+These naming rules do not rename Python APIs or change workflow input behavior.
 
 Keep Typer entry points in `__main__.py`. They parse and validate
 arguments, call the public API and format results; business logic

--- a/skills/startup_profile/SKILL.md
+++ b/skills/startup_profile/SKILL.md
@@ -44,9 +44,10 @@ a successful substantive diagnosis. Consumers can inspect
 conda run -n sictic-env python -m skills.harness '/startup_profile "<STARTUP>"'
 ```
 
-The direct CLI accepts comma-separated `--startup` names and repeated `--files`
+The direct CLI accepts comma-separated `--startups` names and repeated `--files`
 options. It continues after individual startup failures, prints successful
 reports, then exits with code 1 if any failed. The harness handles one startup.
+`--startup` remains a direct CLI alias for `--startups`.
 
 ## References
 

--- a/skills/startup_profile/__main__.py
+++ b/skills/startup_profile/__main__.py
@@ -54,6 +54,7 @@ async def _profile_startups(
 def profile_startup(
     startup: str = typer.Option(
         ...,
+        "--startups",
         "--startup",
         "-s",
         help="Comma-separated startup names",

--- a/skills/startup_website_import/SKILL.md
+++ b/skills/startup_website_import/SKILL.md
@@ -35,7 +35,8 @@ LinkedIn enrichment, and no harness/bulk registration.
 conda run -n sictic-env python -m skills.startup_website_import example https://example.org --depth 1
 ```
 
-The direct CLI exposes `--depth`, `--max-pages`, `--pdfs/--no-pdfs`,
+The direct CLI takes positional `STARTUP` and `URL` arguments and exposes
+`--depth`, `--max-pages`, `--pdfs/--no-pdfs`,
 `--max-pdfs`, `--max-pdf-mb` and `--respect-robots/--ignore-robots`.
 
 ## References

--- a/skills/startup_website_import/__main__.py
+++ b/skills/startup_website_import/__main__.py
@@ -14,7 +14,7 @@ app = typer.Typer(help="Import a startup public website into dataset storage.")
 
 @app.command()
 def main(
-    startup_name: str = typer.Argument(..., help="Startup name for the dataset."),
+    startup_name: str = typer.Argument(..., metavar="STARTUP", help="Startup name for the dataset."),
     url: str = typer.Argument(..., help="Public startup website URL."),
     depth: int = typer.Option(1, "--depth", min=0, help="Internal crawl depth."),
     max_pages: int = typer.Option(

--- a/skills/submission_ready/SKILL.md
+++ b/skills/submission_ready/SKILL.md
@@ -63,7 +63,8 @@ conda run -n sictic-env python -m skills.harness /submission_ready
 conda run -n sictic-env python -m skills.harness '/submission_ready "<STARTUP>"'
 ```
 
-The direct CLI accepts repeated `--startup` options.
+The direct CLI accepts repeated `--startups` options; `--startup` remains an alias.
+The harness accepts multiple positional `startups` separated by spaces.
 
 ## References
 

--- a/skills/submission_ready/__main__.py
+++ b/skills/submission_ready/__main__.py
@@ -16,6 +16,7 @@ app = typer.Typer(
 def run_submission_ready(
     startup: Optional[list[str]] = typer.Option(
         None,
+        "--startups",
         "--startup",
         "-s",
         help=(

--- a/skills/suggested_startups/SKILL.md
+++ b/skills/suggested_startups/SKILL.md
@@ -65,11 +65,12 @@ are also included in that error.
 ## Usage
 
 ```bash
-conda run -n sictic-env python -m skills.harness '/suggested_startups --startups "<startup1>,<startup2>" --investor "<name-or-id1>,<name-or-id2>"'
+conda run -n sictic-env python -m skills.harness '/suggested_startups --startups "<startup1>,<startup2>" --investors "<name-or-id1>,<name-or-id2>"'
 ```
 
 The harness uses comma-separated startup and investor lists. The direct CLI uses
-repeated `--startups` options and a comma-separated `--investor` value.
+repeated `--startups` options and a comma-separated `--investors` value.
+Both retain `--investor` as a compatibility alias for `--investors`.
 Both accept `--max-startups` (default 16); only the Python API exposes
 `dataset_name`.
 

--- a/skills/suggested_startups/__main__.py
+++ b/skills/suggested_startups/__main__.py
@@ -14,6 +14,7 @@ def main(
     startups: Optional[List[str]] = typer.Option(None, "--startups", "-s", help="Repeat for each startup name. If omitted, use startup datasets, excluding configured community and ignored datasets."),
     investor: Optional[str] = typer.Option(
         None,
+        "--investors",
         "--investor",
         "-i",
         help=(

--- a/skills/team_profile_revised/SKILL.md
+++ b/skills/team_profile_revised/SKILL.md
@@ -51,7 +51,7 @@ Editing internal audit JSON alone does not invalidate the final synthesis.
 conda run -n sictic-env python -m skills.harness '/team_profile_revised "<STARTUP>"'
 ```
 
-The direct CLI uses `--dataset`.
+The direct CLI uses `--startup`; `--dataset` and `-d` remain compatibility aliases.
 
 ## References
 

--- a/skills/team_profile_revised/__main__.py
+++ b/skills/team_profile_revised/__main__.py
@@ -10,7 +10,7 @@ app = typer.Typer(help="Assess founder-team checklists and synthesize each categ
 
 @app.command()
 def run_team_profile_revised(
-    dataset_name: str = typer.Option(..., "--dataset", "-d", help="Target startup dataset."),
+    dataset_name: str = typer.Option(..., "--startup", "--dataset", "-s", "-d", help="Target startup dataset."),
 ):
     insights = run_command(
         lambda: team_profile_revised(dataset_name),

--- a/tests/cli/test_parameter_naming.py
+++ b/tests/cli/test_parameter_naming.py
@@ -1,0 +1,192 @@
+"""Canonical CLI names and legacy aliases preserve workflow inputs."""
+
+import importlib
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from typer.main import get_command
+from typer.testing import CliRunner
+
+from skills.harness.harness import dispatch_command, help_text
+
+
+@pytest.mark.parametrize("legacy", [False, True], ids=["canonical", "legacy"])
+@pytest.mark.parametrize(
+    "skill,canonical,old,expected_args,expected_kwargs",
+    [
+        (
+            "investor_profile",
+            ["--dataset", "members", "--persons", "Jane Doe, John Doe"],
+            ["--source-dataset", "members", "--person", "Jane Doe, John Doe"],
+            (),
+            {"source_dataset": "members", "names": ["Jane Doe", "John Doe"]},
+        ),
+        (
+            "person_profile",
+            ["--dataset", "members", "--persons", "Jane Doe, John Doe"],
+            ["--dataset", "members", "--person", "Jane Doe, John Doe"],
+            (),
+            {"dataset_name": "members", "names": ["Jane Doe", "John Doe"]},
+        ),
+        (
+            "suggested_startups",
+            ["--investors", "Jane Doe, John Doe", "--startups", "a", "--startups", "b"],
+            ["--investor", "Jane Doe, John Doe", "--startups", "a", "--startups", "b"],
+            (),
+            {"startups": ["a", "b"], "investors": ["Jane Doe", "John Doe"], "max_startups": 16},
+        ),
+        (
+            "submission_ready",
+            ["--startups", "Example One", "--startups", "Example Two"],
+            ["--startup", "Example One", "--startup", "Example Two"],
+            (["Example One", "Example Two"],),
+            {},
+        ),
+        ("team_profile_revised", ["--startup", "Example One"], ["--dataset", "Example One"], ("Example One",), {}),
+        ("sha_review", ["--startup", "Example One"], ["--dataset", "Example One"], ("Example One",), {}),
+    ],
+)
+def test_selectors_preserve_python_calls(
+    monkeypatch, legacy, skill, canonical, old, expected_args, expected_kwargs,
+):
+    module = importlib.import_module(f"skills.{skill}.__main__")
+    workflow = AsyncMock(return_value=[])
+    monkeypatch.setattr(module, skill, workflow)
+
+    result = CliRunner().invoke(module.app, old if legacy else canonical)
+
+    assert result.exit_code == 0, result.output
+    workflow.assert_awaited_once_with(*expected_args, **expected_kwargs)
+
+
+@pytest.mark.parametrize("option", ["--startups", "--startup"])
+def test_startup_profile_batch_keeps_files_order_and_failure_behavior(monkeypatch, option):
+    module = importlib.import_module("skills.startup_profile.__main__")
+    workflow = AsyncMock(side_effect=[RuntimeError("fixture failure"), []])
+    monkeypatch.setattr(module, "startup_profile", workflow)
+
+    result = CliRunner().invoke(
+        module.app,
+        [option, "Example One, , Example Two", "--files", "one.pdf", "--files", "two.pdf"],
+    )
+
+    assert result.exit_code == 1
+    assert "fixture failure" in result.output
+    assert [call.args for call in workflow.await_args_list] == [
+        ("Example One", ["one.pdf", "two.pdf"]),
+        ("Example Two", ["one.pdf", "two.pdf"]),
+    ]
+
+
+@pytest.mark.parametrize("option", ["--datasets", "--dataset"])
+@pytest.mark.parametrize(
+    "command,operation",
+    [("activate", "activate_dataset_marker"), ("archive", "archive_dataset_marker"), ("rebuild-index", "rebuild_dataset_index")],
+)
+def test_maintenance_batch_selectors_keep_scope_and_sync(monkeypatch, option, command, operation):
+    module = importlib.import_module("skills.dataset_maintenance.__main__")
+    workflow = Mock(side_effect=lambda dataset: SimpleNamespace(
+        dataset=dataset, collection="fixture", collection_deleted=True, documents_reset=2,
+    ))
+    sync = AsyncMock(return_value=[])
+    monkeypatch.setattr(module, operation, workflow)
+    monkeypatch.setattr(module, "sync_datasets", sync)
+
+    result = CliRunner().invoke(module.app, [command, option, "a, , b"])
+
+    assert result.exit_code == 0, result.output
+    assert [call.args for call in workflow.call_args_list] == [("a",), ("b",)]
+    if command == "rebuild-index":
+        sync.assert_awaited_once_with(["a", "b"], raise_on_error=True)
+    else:
+        sync.assert_not_awaited()
+
+
+@pytest.mark.parametrize("option", ["--source-datasets", "--source-dataset"])
+def test_source_and_target_roles_remain_distinct(monkeypatch, option):
+    module = importlib.import_module("skills.dataset_maintenance.__main__")
+    workflow = AsyncMock(return_value=[])
+    monkeypatch.setattr(module, "dataset_from_insight", workflow)
+
+    result = CliRunner().invoke(module.app, [
+        "dataset-from-insight", "--target-dataset", "output",
+        option, "a,b", "--skill", "person_profile", "--dry-run",
+    ])
+
+    assert result.exit_code == 0, result.output
+    workflow.assert_awaited_once_with("output", ["a", "b"], "person_profile", dry_run=True)
+
+
+def test_delete_remains_a_single_dataset_operation(monkeypatch):
+    module = importlib.import_module("skills.dataset_maintenance.__main__")
+    workflow = Mock(return_value=[])
+    monkeypatch.setattr(module, "delete_dataset_index", workflow)
+
+    result = CliRunner().invoke(module.app, ["delete", "--dataset", "a"])
+    assert result.exit_code == 0, result.output
+    workflow.assert_called_once_with("a", None)
+    workflow.reset_mock()
+
+    result = CliRunner().invoke(module.app, ["delete", "--datasets", "a,b"])
+    assert result.exit_code == 2
+    workflow.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("option", ["--dataset", "--source-dataset"])
+async def test_harness_investor_dataset_aliases(monkeypatch, option):
+    module = importlib.import_module("skills.investor_profile.investor_profile")
+    workflow = AsyncMock(return_value=[])
+    monkeypatch.setattr(module, "investor_profile", workflow)
+
+    await dispatch_command(["/investor_profile", option, "Example Members"])
+
+    workflow.assert_awaited_once_with(source_dataset="Example Members")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("option", ["--investors", "--investor"])
+async def test_harness_investor_list_aliases(monkeypatch, option):
+    module = importlib.import_module("skills.suggested_startups.suggested_startups")
+    workflow = AsyncMock(return_value=[])
+    monkeypatch.setattr(module, "suggested_startups", workflow)
+
+    await dispatch_command([
+        "/suggested_startups", "--startups", "a,b", option, "Jane Doe, John Doe",
+    ])
+
+    workflow.assert_awaited_once_with(
+        startups=["a", "b"], investors=["Jane Doe", "John Doe"], max_startups=16,
+    )
+
+
+@pytest.mark.parametrize(
+    "skill,subcommand,argument,metavar",
+    [
+        ("dealum_import", None, "startup", "STARTUPS"),
+        ("startup_website_import", None, "startup_name", "STARTUP"),
+        ("dataset_maintenance", "create", "startup_name", "STARTUP"),
+        ("dataset_chat", "search", "dataset_name", "DATASET"),
+        ("dataset_chat", "chat", "dataset_name", "DATASET"),
+        ("dataset_chat", "chat", "questions", "QUESTION"),
+        ("dataset_chat", "sync", "dataset_names", "DATASETS..."),
+    ],
+)
+def test_positional_labels_express_subject_and_cardinality(skill, subcommand, argument, metavar):
+    module = importlib.import_module(f"skills.{skill}.__main__")
+    command = get_command(module.app)
+    if subcommand:
+        command = command.commands[subcommand]
+    parameter = next(item for item in command.params if item.name == argument)
+    assert parameter.metavar == metavar
+
+
+def test_harness_help_advertises_canonical_selectors():
+    text = help_text()
+    assert "/investor_profile [--dataset dataset]" in text
+    assert "--investors x,y" in text
+    assert "/sha_review <startup>" in text
+    assert "/submission_ready [startups ...]" in text
+    assert "--source-dataset" not in text
+    assert "--investor " not in text

--- a/tests/harness/test_harness.py
+++ b/tests/harness/test_harness.py
@@ -73,10 +73,10 @@ def test_harness_help_lists_core_commands():
 
     assert "/dataset_chat <dataset> <question>" in text
     assert "/startup_profile <startup>" in text
-    assert "/submission_ready [startup ...]" in text
+    assert "/submission_ready [startups ...]" in text
     assert "/dd_checks <startup>" in text
     assert "/dd_priorities <startup>" in text
-    assert "/sha_review <dataset>" in text
+    assert "/sha_review <startup>" in text
     assert "/dealum_import <startup>" in text
 
 

--- a/tests/skill_harness/cases.py
+++ b/tests/skill_harness/cases.py
@@ -50,7 +50,7 @@ HARNESS_SMOKE_COMMANDS = {
     "/person_profile": "/person_profile sictic-members Jane Doe",
     "/team_profile": "/team_profile example-startup",
     "/team_profile_revised": "/team_profile_revised example-startup",
-    "/investor_profile": "/investor_profile --source-dataset sictic-members",
+    "/investor_profile": "/investor_profile --dataset sictic-members",
     "/expert_search": "/expert_search example-startup",
     "/potential_investors": "/potential_investors example-startup",
     "/member_preferences": "/member_preferences",
@@ -61,7 +61,7 @@ HARNESS_SMOKE_COMMANDS = {
     "/advocates": "/advocates fixture-event --description Fixture event",
     "/suggested_startups": (
         "/suggested_startups --startups example-startup "
-        "--investor Jane Doe --max-startups 1"
+        "--investors Jane Doe --max-startups 1"
     ),
     "/dd_checks": "/dd_checks example-startup",
     "/dd_priorities": "/dd_priorities example-startup",

--- a/tests/skills/test_deep_dive_invitation.py
+++ b/tests/skills/test_deep_dive_invitation.py
@@ -130,4 +130,4 @@ async def test_deep_dive_invitation_renders_review_only_draft(
     assert "### Industry Experts: FYI" not in email
     assert "To:  \nJane Founder <jane@startup.ch>  \n\nCc:" in email
     assert "Member preference opt-outs excluded from expert search: 1" in content
-    assert "Interested members excluded from expert search: 1" in content
+    assert "Interested investors with an email in Cc: 1" in content

--- a/tests/skills/test_deep_dive_invitation_freshness.py
+++ b/tests/skills/test_deep_dive_invitation_freshness.py
@@ -1,0 +1,210 @@
+from copy import deepcopy
+from importlib import import_module
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from lib.datasets.manifest import IngestionManifest
+from lib.datasets.paths import dataset_location_for_domain
+from lib.infrastructure.configuration import load_repository_config
+from lib.insights import InsightFile
+from lib.people import Person
+from lib.storage import get_storage
+
+
+@pytest.fixture
+def invitation(monkeypatch, mock_env):
+    module = import_module("skills.deep_dive_invitation.deep_dive_invitation")
+    monkeypatch.setenv("RANKED_LLMS", "ollama/test_model:1b")
+    monkeypatch.setattr(module, "llm_model", lambda: "ollama/test_model:1b")
+    manifests = {}
+    for dataset, domain in [("example-startup", "startups"), ("sictic-members", "community")]:
+        location = dataset_location_for_domain(dataset, domain)
+        get_storage().mkdir(location.raw_rel)
+        manifest = IngestionManifest(get_storage(), location.parsed_rel)
+        manifest.indexed_dataset_revision = "revision-one"
+        manifest.save()
+        manifests[dataset] = manifest
+
+    config = deepcopy(load_repository_config("deep_dive_invitation"))
+    monkeypatch.setattr(module, "load_repository_config", lambda *_: config)
+    expert = InsightFile("example-startup", "expert_search", "manual")
+    expert.save("| Rank | Full Name | Email Addresses | LinkedIn ID | Rationale |\n"
+                "|---|---|---|---|---|\n")
+    dependencies = [
+        AsyncMock(return_value=SimpleNamespace(
+            dataset_slug="example-startup", dealum_name="Example Startup",
+            dealum_url="https://dealum.example/1", application_path=None,
+        )),
+        AsyncMock(return_value=[]),
+        Mock(return_value=[]),
+        AsyncMock(return_value=[expert]),
+    ]
+    for name, dependency in zip(
+        ["dealum_import", "startup_profile", "member_preferences", "expert_search"],
+        dependencies,
+    ):
+        monkeypatch.setattr(module, name, dependency)
+    return SimpleNamespace(
+        run=module.deep_dive_invitation, config=config, manifests=manifests,
+        dependencies=dependencies, expert=expert,
+    )
+
+
+def assert_dependencies_not_called(invitation):
+    for dependency in invitation.dependencies:
+        dependency.assert_not_called()
+
+
+def reset_dependencies(invitation):
+    for dependency in invitation.dependencies:
+        dependency.reset_mock()
+
+
+@pytest.mark.asyncio
+async def test_manual_returns_before_dependencies_even_without_indexed_revisions(invitation):
+    manual = InsightFile("example-startup", "deep_dive_invitation", "manual")
+    manual.save("Human-edited invitation")
+    for manifest in invitation.manifests.values():
+        manifest.indexed_dataset_revision = ""
+        manifest.save()
+    for dependency in invitation.dependencies:
+        dependency.side_effect = AssertionError("No dependency should run")
+
+    [result] = await invitation.run("Example Startup")
+
+    assert result.path == manual.path
+    assert result.content() == "Human-edited invitation"
+    assert_dependencies_not_called(invitation)
+
+
+@pytest.mark.asyncio
+async def test_fresh_generated_returns_before_all_dependencies(invitation):
+    [first] = await invitation.run("Example Startup")
+    assert first.is_reusable()
+    assert first.source_datasets == ["example-startup", "sictic-members"]
+    reset_dependencies(invitation)
+    # Dependency reports are deliberately no longer part of invitation freshness.
+    invitation.expert.save("Edited expert report")
+    for dependency in invitation.dependencies:
+        dependency.side_effect = AssertionError("Cache hit must not run dependencies")
+
+    [result] = await invitation.run("Example Startup")
+
+    assert result.path == first.path
+    assert result.content() == first.content()
+    assert_dependencies_not_called(invitation)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("change", [
+    "example-startup", "sictic-members", "missing-revision", "template",
+    "settings", "founders", "investors",
+])
+async def test_stale_generated_runs_dependencies(invitation, change):
+    [first] = await invitation.run("Example Startup")
+    reset_dependencies(invitation)
+    kwargs = {}
+    if change in invitation.manifests:
+        invitation.manifests[change].indexed_dataset_revision = "revision-two"
+        invitation.manifests[change].save()
+    elif change == "missing-revision":
+        invitation.manifests["sictic-members"].indexed_dataset_revision = ""
+        invitation.manifests["sictic-members"].save()
+    elif change == "template":
+        invitation.config["email_template"] += "\nUpdated invitation wording.\n"
+    elif change == "settings":
+        invitation.config["settings"]["max_experts"] = 9
+    else:
+        kwargs[change] = [Person(full_name="New Contact", email_addresses=["new@example.com"])]
+
+    [result] = await invitation.run("Example Startup", **kwargs)
+
+    assert result.path == first.path
+    for dependency in invitation.dependencies:
+        dependency.assert_called_once()
+    if change == "template":
+        assert "Updated invitation wording." in result.content()
+
+
+@pytest.mark.asyncio
+async def test_locally_known_alias_returns_before_import(invitation, monkeypatch):
+    identity = import_module("lib.startups.identity")
+    monkeypatch.setattr(identity, "startup_aliases", lambda: {"old-name": "example-startup"})
+    manual = InsightFile("example-startup", "deep_dive_invitation", "manual")
+    manual.save("Manual invitation")
+
+    [result] = await invitation.run("Old Name")
+
+    assert result.path == manual.path
+    assert_dependencies_not_called(invitation)
+
+
+@pytest.mark.asyncio
+async def test_application_code_checks_resolved_dataset_before_other_dependencies(invitation):
+    [first] = await invitation.run("Example Startup")
+    reset_dependencies(invitation)
+
+    [result] = await invitation.run("ABCD-1234")
+
+    assert result.path == first.path
+    invitation.dependencies[0].assert_awaited_once_with("ABCD-1234")
+    for dependency in invitation.dependencies[1:]:
+        dependency.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_application_code_saves_under_resolved_slug_on_cache_miss(invitation):
+    [result] = await invitation.run("ABCD-1234")
+
+    assert result.dataset == "example-startup"
+    assert result.source_datasets == ["example-startup", "sictic-members"]
+    assert result.is_reusable()
+    invitation.dependencies[1].assert_awaited_once_with("example-startup")
+
+
+@pytest.mark.asyncio
+async def test_cc_changes_keep_ranking_request_identical_and_filter_before_limit(invitation):
+    interested = Person(
+        full_name="Interested Member", linkedin_id="interested-member",
+        email_addresses=["member@gmail.com", "member@investor.sictic.ch"],
+    )
+    available = Person(
+        full_name="Available Expert", linkedin_id="available-expert",
+        email_addresses=["expert@investor.sictic.ch"],
+    )
+    opted_out = Person(
+        full_name="Opted Out", linkedin_id="opted-out",
+        email_addresses=["out@investor.sictic.ch"],
+        adhoc_data={"member_preferences": {"deep_dive_invitation": "none"}},
+    )
+    invitation.dependencies[2].return_value = [interested, available, opted_out]
+    invitation.config["settings"]["max_experts"] = 1
+    invitation.expert.save(
+        "| Rank | Full Name | Email Addresses | LinkedIn ID | Rationale |\n"
+        "|---|---|---|---|---|\n"
+        "| 1 | Interested Member | member@investor.sictic.ch | interested-member | Fit |\n"
+        "| 2 | Opted Out | out@investor.sictic.ch | opted-out | Fit |\n"
+        "| 3 | Available Expert | expert@investor.sictic.ch | available-expert | Fit |\n"
+    )
+
+    [first] = await invitation.run("Example Startup", investors=[Person(
+        full_name="Interested Member", email_addresses=["member@gmail.com"],
+    )])
+    first_content = first.content()
+    assert "Cc:  \nInterested Member <member@gmail.com>" in first_content
+    assert "Bcc:  \nAvailable Expert <expert@investor.sictic.ch>" in first_content
+    assert "member@investor.sictic.ch" not in first_content
+    assert "out@investor.sictic.ch" not in first_content
+    assert "Interested investors with an email in Cc: 1" in first_content
+    invitation.dependencies[3].assert_awaited_once_with(
+        "example-startup", exclude_experts=["opted-out"], top_k=16,
+    )
+    first_request = invitation.dependencies[3].await_args
+
+    [second] = await invitation.run("Example Startup")
+
+    assert invitation.dependencies[3].await_count == 2
+    assert invitation.dependencies[3].await_args == first_request
+    assert "Bcc:  \nInterested Member <member@investor.sictic.ch>" in second.content()

--- a/tests/utils/test_insight_reuse_logging.py
+++ b/tests/utils/test_insight_reuse_logging.py
@@ -1,0 +1,125 @@
+import json
+import logging
+
+import pytest
+
+from lib.datasets.manifest import IngestionManifest
+from lib.datasets.paths import dataset_location_for_domain
+from lib.insights import InsightFile
+from lib.storage import get_storage
+
+
+@pytest.fixture
+def cached_insight(mock_env, monkeypatch, caplog):
+    monkeypatch.setenv("RANKED_LLMS", "ollama/test-model")
+    caplog.set_level(logging.INFO, logger="lib.insights.selection")
+    manifests = {}
+    for dataset, domain in [("ovomind", "startups"), ("sictic-members", "community")]:
+        location = dataset_location_for_domain(dataset, domain)
+        get_storage().mkdir(location.raw_rel)
+        manifest = IngestionManifest(get_storage(), location.parsed_rel)
+        manifest.indexed_dataset_revision = "revision-one"
+        manifest.save()
+        manifests[dataset] = manifest
+    insight = InsightFile(
+        "ovomind", "expert_search", "ollama/test-model",
+        source_datasets=["ovomind", "sictic-members"],
+        config_key="private prompt and contacts",
+    )
+    insight.save("Stored result")
+    caplog.clear()
+    return insight, manifests
+
+
+@pytest.mark.parametrize("change,reason", [
+    ("dataset", "dataset changed: sictic-members"),
+    ("prompt", "prompt/configuration/inputs changed"),
+    ("both", "dataset changed: sictic-members; prompt/configuration/inputs changed"),
+    ("entry", "freshness metadata missing"),
+    ("model", "stored model mismatch"),
+    ("incomplete", "freshness metadata missing or invalid"),
+    ("revision", "indexed revision missing: sictic-members"),
+])
+def test_cache_miss_reasons(cached_insight, caplog, change, reason):
+    insight, manifests = cached_insight
+    if change in {"dataset", "both", "revision"}:
+        manifest = manifests["sictic-members"]
+        manifest.indexed_dataset_revision = "" if change == "revision" else "revision-two"
+        manifest.save()
+    if change in {"prompt", "both"}:
+        insight.config_key = "new private prompt and contacts"
+    if change in {"entry", "model", "incomplete"}:
+        metadata = insight._load_manifest()
+        if change == "entry":
+            metadata["entries"].pop(insight.path)
+        elif change == "model":
+            metadata["entries"][insight.path]["model"] = "other-model"
+        else:
+            metadata["entries"][insight.path].pop("config_sha256")
+        get_storage().write_text(insight._manifest_path, json.dumps(metadata))
+
+    assert insight.find(selection="reusable") is None
+    messages = [record.getMessage() for record in caplog.records if record.name == "lib.insights.selection"]
+    assert len(messages) == 1
+    assert messages[0].startswith("[ovomind/expert_search] Cache miss")
+    assert reason in messages[0]
+    assert "private prompt and contacts" not in caplog.text
+
+
+def test_missing_candidates(cached_insight, caplog, monkeypatch):
+    insight, _ = cached_insight
+    monkeypatch.setenv("RANKED_LLMS", "ollama/absent-model")
+    assert insight.find(selection="reusable") is None
+    assert "[ovomind/expert_search] Cache miss: no existing candidate files" in caplog.text
+
+
+def test_manual_hit_precedes_revision_checks(cached_insight, caplog):
+    insight, manifests = cached_insight
+    manual = insight._candidate("manual")
+    manual.save("Human edited")
+    manifest = manifests["sictic-members"]
+    manifest.indexed_dataset_revision = ""
+    manifest.save()
+    caplog.clear()
+
+    assert insight.find(selection="reusable").path == manual.path
+    assert "[ovomind/expert_search] Reusing manual version" in caplog.text
+    assert "Cache miss" not in caplog.text
+
+
+def test_rejected_model_does_not_prevent_lower_ranked_reuse(cached_insight, caplog, monkeypatch):
+    insight, _ = cached_insight
+    stale = InsightFile(
+        "ovomind", "expert_search", "ollama/stale-model",
+        source_datasets=insight.source_datasets, config_key="old prompt",
+    )
+    stale.save("Stale result")
+    monkeypatch.setenv("RANKED_LLMS", "ollama/stale-model,ollama/test-model")
+    caplog.clear()
+
+    assert insight.find(selection="reusable").path == insight.path
+    assert "Cache miss (stale-model): prompt/configuration/inputs changed" in caplog.text
+    assert "Reusing generated version (test-model)" in caplog.text
+    assert insight.path in caplog.text
+
+
+def test_legacy_hash_reuses_without_false_miss(cached_insight, caplog):
+    insight, _ = cached_insight
+    metadata = insight._load_manifest()
+    entry = metadata["entries"][insight.path]
+    entry["prompt_sha256"] = entry.pop("config_sha256")
+    get_storage().write_text(insight._manifest_path, json.dumps(metadata))
+
+    assert insight.find(selection="reusable").path == insight.path
+    assert "Reusing generated version (test-model)" in caplog.text
+    assert "Cache miss" not in caplog.text
+
+
+def test_reports_all_changed_dataset_names(cached_insight, caplog):
+    insight, manifests = cached_insight
+    for manifest in manifests.values():
+        manifest.indexed_dataset_revision = "revision-two"
+        manifest.save()
+
+    assert insight.find(selection="reusable") is None
+    assert "dataset changed: ovomind, sictic-members" in caplog.text


### PR DESCRIPTION
## Summary

Deep-dive invitations now return a manual or fresh generated draft before running their dependencies. Changing Cc recipients no longer changes the expert-search request: only member-preference opt-outs are passed to ranking, and Cc recipients are filtered from its results by member identity and email before the Bcc limit.

- Standardize CLI and harness parameter names by subject and cardinality, retaining existing flags as compatibility aliases and preserving Python APIs and input formats.
- Update the invitation email wording, preparation links, lead-investor guidance and Dealum reminders.
- Base invitation freshness on the startup and `sictic-members` indexed revisions, template/settings and supplied contacts. Resolve unknown Dealum application codes before checking the canonical dataset.
- Add shared INFO logging for reuse and cache misses, naming changed datasets and distinguishing configuration/input mismatches, missing metadata and missing indexed revisions without logging prompt/contact contents.
- Update skill documentation and add regression coverage for aliases, early reuse, invalidation, Cc filtering and logging.

## Compatibility

Manual precedence, artifact naming and registry orchestration are preserved. Existing generated invitations refresh once under the new cache key/settings version. Invitation freshness uses recorded indexed revisions; unindexed source changes or direct edits to dependency reports do not independently invalidate a draft. After Cc filtering, fewer than ten usable experts may remain in the sixteen returned candidates.

## Validation

- 307 tests passed across CLI, harness, skill contracts, invitation rendering/freshness, insight selection/logging and startup-ranking freshness.
- `git diff --check` passed.
- Ran the OVOMIND invitation workflow and confirmed the existing expert-search result was reused while the revised invitation was saved. No email was sent.
