### PR TITLE
Design: lender-side review of a CLA term sheet (cla_review)

### DIFF
--- a/docs/cla-review-design.md
+++ b/docs/cla-review-design.md
@@ -1,6 +1,6 @@
 # CLA term sheet review — design
 
-Status: proposal for discussion (Enrico, Lucas and Manfred). Companion to issue #__. This document explains how the existing pieces work together and how the new skill sits on top of them. It is written to give an overview for readers over the whole toolkit. Scope: the term sheet of a convertible loan. A priced-round term sheet is a possible later extension on the same skeleton and is not covered here.
+Status: proposal for discussion (Enrico, Lucas and Manfred). Companion to issue #73. This document explains how the existing pieces work together and how the new skill sits on top of them. It is written to give an overview for readers over the whole toolkit. Scope: the term sheet of a convertible loan. A priced-round term sheet is a possible later extension on the same skeleton and is not covered here.
 
 ## 1. The problem in one paragraph
 

--- a/docs/cla-review-design.md
+++ b/docs/cla-review-design.md
@@ -1,6 +1,6 @@
 # CLA term sheet review — design
 
-Status: proposal for discussion (Enrico, Lucas and Manfred). Companion to issue #73. This document explains how the existing pieces work together and how the new skill sits on top of them. It is written to give an overview for readers over the whole toolkit. Scope: the term sheet of a convertible loan. A priced-round term sheet is a possible later extension on the same skeleton and is not covered here.
+Status: implementation design; domain rules and thresholds marked provisional below still require review (Enrico, Lucas and Manfred). Companion to issue #73. This document explains how the existing pieces work together and how the new skill sits on top of them. It is written to give an overview for readers over the whole toolkit. Scope: the term sheet of a convertible loan. A priced-round term sheet is a possible later extension on the same skeleton and is not covered here.
 
 ## 1. The problem in one paragraph
 
@@ -53,7 +53,7 @@ flowchart LR
 
 **`sha_review` supplies the review pattern.** Model-selected document, path resolved only for that candidate; two SECA references ranked; `lib.batch_audit` over checklists with the full document and the reference in the cacheable prefix; synthesis. For the new skill this is the lender-perspective judgment layer, with the two SECA CLA term sheets as references.
 
-**Shared foundations.** `InsightFile` owns every artifact: naming, manual precedence, freshness by source revision and configuration key. `generate_json` with a reviewer is the only way the model returns structured data.
+**Shared foundations.** `InsightFile` owns every artifact: naming, manual precedence, freshness by source revision and configuration key. `generate_json` is the shared entry point for structured model output. Follow the current [JSON validation contract](../skills/standards_and_architecture/SKILL.md#model-calls): `repair_json_payload` repairs unambiguous JSON syntax, `validate_json_schema` checks structure without modifying data, and an optional business reviewer checks evidence and domain consistency. Generation owns this sequence and correction retries; callers do not repeat validation of unchanged generated output. Loaded and assembled JSON uses `validate_json_schema` with the canonical response schema composed into its artifact envelope. Audit fields, required values and scoring constraints belong in the caller-supplied response schema; rubric and missing-evidence policy belong in the prompt.
 
 ## 4. The new skill
 
@@ -80,7 +80,7 @@ flowchart TB
 
 **1. Identify.** One term sheet is under review. Default: the model selects the most recent CLA term sheet in the data room with three retrieval queries, the code resolves that path only, and executed loans are excluded as candidates because they are context, not subject. Optional `--document` names the file directly, for the common case where the deal lead knows which draft the members are about to sign. Classification results from `captable_build`, when present, seed the candidates.
 
-**2. Extract.** `extract_cla` as it exists, over `cla_terms.md` extended with the fields a term sheet carries and a loan agreement does not: aggregate investment amount and range, lead investor and accession of further investors, reduction subject to existing shareholders' pre-emption rights, conversion share class, non-qualified-financing voluntary conversion, conditions precedent, representations and covenants (long form), list of binding provisions, documentation counsel. Adding fields is safe by design; the guarded fields stay untouched. Every value carries a verbatim quote, and absence is a recorded claim.
+**2. Extract.** `extract_cla` as it exists, over `cla_terms.md` extended with the fields a term sheet carries and a loan agreement does not: aggregate investment amount and range, lead investor and accession of further investors, reduction subject to existing shareholders' pre-emption rights, conversion share class, non-qualified-financing voluntary conversion, conditions precedent, representations and covenants (long form), list of binding provisions, documentation counsel. Keep the guarded fields unchanged, but treat added fields as a shared contract change: every checklist field becomes required in the generated schema. Generated extracts and their dependents must regenerate under the new configuration. Existing manual artifacts must be updated to satisfy the new schema and must never be silently overwritten. Invalid manual artifacts raise a clear validation error. There is no legacy schema or compatibility layer; regression tests cover generated invalidation and manual validation. Every value carries a verbatim quote, and absence is a recorded claim.
 
 ### Question 1: the terms themselves
 
@@ -100,7 +100,7 @@ flowchart TB
 | Binding provisions | limited to confidentiality, costs, effect, law | economic terms declared binding, or exclusivity |
 | Documentation | SECA CLA short or long form referenced | bespoke or unnamed |
 
-The bands are marked "to verify" until confirmed (Enrico, Luc?), as `assessment_rules.json` does today.
+Separate approved rules from provisional rules and thresholds in configuration. Each enabled rule records its source, review status and effective date, with dated values where applicable. Unapproved rules and thresholds remain inactive: the report may raise an open question but must not issue a judgment based on an unapproved threshold. The proposals below do not constitute domain approval.
 
 Proposed first set of lender-angle bands for `config/cla_review/settings.json`. Every value is a proposal to verify; sources are named where they exist, placeholders are marked as such.
 
@@ -123,13 +123,15 @@ Proposed first set of lender-angle bands for `config/cla_review/settings.json`. 
 | Member count N for the before-and-after | 5 | SICTIC syndicate practice; placeholder | placeholder |
 | Valuation range for the conversion table | 0.5x to 3x the cap | for the cap-versus-discount crossover | placeholder |
 
-Rows marked "rule, no number" are switches rather than bands; they live in the same file so they can be turned off. The non-bank thresholds are the only fixed values. The safe-harbor rate changes every year and belongs in a dated setting, not in code.
+Rows marked "rule, no number" are switches rather than bands; they live in the same file so they can be turned off. The non-bank row describes a proposed sourced rule, not an exemption from domain review: its applicability and counting assumptions must be approved before enabling it. The safe-harbor rate changes every year and belongs in a dated setting, not in code. All rows in the table above, including qualitative switches and rows labelled "fixed", remain inactive until their review status is approved.
 
 **4. Audit against the SECA CLA term sheets.** sha_review pattern: rank the SECA short form and long form and run `lib.batch_audit` over checklists written from the lender's perspective, seeded from the earlier sketch: cap and discount interplay, maturity mechanism and price, conversion via consents versus conditional capital and who can block, QEFR realism, lender-majority definition, information rights, pro-rata and MFN, interest versus safe harbor, subordination scope, change-of-control multiple, stamp-duty position on conversion, syndicate or pooling vehicle, execution evidence. The audits cover what bands cannot: wording, consistency, and what the term sheet promises the definitive agreement will contain.
 
 ### Question 2: the terms in this company
 
-**5. My conversion on this cap table.** From the consolidated `captable_build` insight and `model.py`, for the member's own ticket (an amount given on the command line, default the term sheet's minimum): shares and ownership on conversion at the cap, at the discount and at the floor for a range of next-round pre-money valuations, the price at which cap and discount cross, the effect of interest accrued to an assumed conversion date, ownership after the existing loans convert alongside, and stamp duty on conversion. If no snapshot exists the step yields an insufficient-evidence finding, not a failure.
+**5. My conversion on this cap table.** From the consolidated `captable_build` insight and `model.py`, for the member's own ticket (an amount given on the command line, default an evidenced per-member minimum, subject to the input policy below): shares and ownership on conversion at the cap, at the discount and at the floor for a range of next-round pre-money valuations, the price at which cap and discount cross, the effect of interest accrued to an assumed conversion date, ownership after the existing loans convert alongside, and stamp duty on conversion. Use the canonical read-only `lib.captable.insights.select_consolidated` and `read_build_insight` helpers. An absent or stale generated snapshot yields an explicit insufficient-evidence finding; malformed artifacts and other technical failures remain errors and are not relabelled as missing evidence. Do not run `captable_build` implicitly.
+
+Before calculating, resolve and display the ticket and currency, new round investment, conversion date, denominator basis and shares, participating existing loans, and the aggregate participation of other new lenders. A member ticket alone does not represent the whole proposed loan. Record which inputs are evidenced and which are explicit scenario assumptions, including the round method. Include all effective inputs, dependency content and date-dependent assumptions in freshness keys. If an essential input is unavailable, omit the affected calculation and explain what is missing rather than inventing it. For uncapped loans, use an explicit valuation grid from settings or supplied scenario data, independent of a cap; if unavailable, omit that scenario table. Test missing inputs, uncapped loans and different participation assumptions.
 
 **6. The existing loans.** Every outstanding CLA in the insight is compared with the term sheet: cap, discount, denominator, maturity, interest, subordination side by side; whether an MFN clause in any existing loan pulls the term sheet's terms into it or vice versa; whether the term sheet would join an identical-terms group; and the SICTIC-specific number, the lender count and the largest identical-terms group with and without N members joining on these terms, against the 10 and 20 thresholds of the non-bank rules, reusing the aggregation code. Maturities are listed together so a cluster is visible.
 
@@ -137,9 +139,9 @@ Rows marked "rule, no number" are switches rather than bands; they live in the s
 
 **8. Report.** Deterministic tables (terms with quotes, absent clauses, company-angle and lender-angle assessments, my conversion table, existing-loan comparison, 10/20 before and after, executability checklist) followed by a synthesis in the `sha_review` format: numbered findings with status, supporting checks, why it matters, recommended follow-up, closing with "not legal advice".
 
-**Artifacts.** JSON insights `identification`, `extraction`, `assessment`, `conversion`, `loan-context`, `sha-context`, `audits/<checklist>` under `insights/cla-review/`, and one Markdown report `cla-review-<startup>-<document>-<model>.md` directly under `insights/`, one per reviewed document. Manual files take precedence, `--fresh` discards generated work, failures are never reused.
+**Artifacts.** Use the canonical selected document identity, retaining enough path identity to distinguish equal basenames, through `InsightFile` for every document-specific intermediate and final artifact; do not implement separate filename normalization. JSON insights `identification`, `extraction`, `assessment`, `conversion`, `loan-context`, `sha-context`, `audits/<checklist>` under `insights/cla-review/`, and one Markdown report `cla-review-<startup>-<document>-<model>.md` directly under `insights/`, one per reviewed document. Intermediate identifiers, including audit identifiers, must include the document identity, not only the stage or checklist name. Identification reuse must distinguish explicit document selection from automatic selection. Ticket and scenario inputs belong in configuration keys; a new scenario replaces the generated result for that document rather than creating a new naming convention. Same-document writes follow shared lifecycle behavior; different documents must never share intermediate paths. Manual files take precedence, `--fresh` bypasses generated reuse without deleting files or overriding manual inputs, and failures are never reused. Test two document reviews, including equal basenames in different folders, for isolation and test scenario changes for invalidation.
 
-**Interfaces.** `cla_review(dataset_name, *, document=None, ticket=None, fresh=False) -> list[InsightFile]`; CLI `python -m skills.cla_review --startup <name> [--document <file>] [--ticket <amount>]`; harness `/cla_review <startup> [--document f] [--ticket n]`; registry `cla-review`, domain `startups`, soft dependency on `captable-build`.
+**Interfaces.** `cla_review(dataset_name, *, document=None, ticket=None, fresh=False) -> list[InsightFile]`; CLI `python -m skills.cla_review --startup <name> [--document <file>] [--ticket <amount>]`; harness `/cla_review <startup> [--document f] [--ticket n]`; registry `cla-review`, domain `startups`, no registry prerequisite on `captable-build`; it is an optional existing input.
 
 ## 5. Reference material
 
@@ -149,12 +151,12 @@ Rows marked "rule, no number" are switches rather than bands; they live in the s
 
 ## 6. Decisions that touch existing contracts
 
-1. **Extend `cla_terms.md` rather than fork it.** The term-sheet-only fields are added to the shared checklist; `captable_build` extracts them too and ignores them. Alternative: a second checklist file for term sheets, which would duplicate 40 fields. Recommendation: extend.
+1. **Extend `cla_terms.md` rather than fork it.** The term-sheet-only fields are added to the shared checklist; `captable_build` extracts them too and does not assess them with its existing rules. Regenerate generated extracts and dependents; manual artifacts must satisfy the expanded schema. Retain regression coverage, with no legacy support. Alternative: a second checklist file for term sheets, which would duplicate 40 fields. Recommendation: extend.
 2. **Lender-angle rules next to `assess_cla`.** New module in `lib/captable/` (or `lib/cla_review/`), same finding shape, separate settings file. `assess_cla` is not changed.
 3. **Document-scoped entry point.** `--document` on a dataset-scoped skill is new. Alternative: always auto-identify. Recommendation: both, with `--document` optional. No entry point for a file outside the data room; the draft goes into the startup's `datasets/` folder and is synced, as every skill assumes.
-4. **Ticket amount as an input.** `--ticket` is a user input that shapes the output; it goes into the configuration key so a different ticket produces a different insight. Recommendation: accept it, default to the term sheet's minimum or the aggregate amount divided by the expected member count from settings.
-5. **Audit status scale.** Keep `unclear | too weak | balanced | too strong` from `sha_review`, read from the lender's side in the checklist wording.
-6. **Dependency.** Soft on `captable-build`. Question 1 works without a snapshot; question 2 then reports insufficient evidence.
+4. **Ticket amount as an input.** `--ticket` is a user input that shapes the output; it goes into the configuration key so a different ticket invalidates generated reuse for the same document. Recommendation: accept it, use an evidenced per-member minimum, or an explicitly labelled scenario assumption dividing the aggregate amount by the configured member count. If neither is available, omit ticket-dependent calculations. Never mistake a minimum aggregate raise for a member minimum.
+5. **Audit status scale.** Define `unclear | too weak | balanced | too strong` in the caller-owned response schema, with lender-perspective rubric and missing-evidence instructions in the prompt. Use the current schema-driven `batch_audit` API and shared artifact validation.
+6. **Dependency.** Consume an optional existing `captable-build` insight through its canonical reader, without a registry prerequisite or implicit generation. Question 1 works without a reusable snapshot; snapshot-dependent parts of question 2 report insufficient evidence. Preserve the distinction between absent/stale input and malformed data or technical failures. Tests cover absent, stale, invalid and reusable snapshots. If a bulk run also builds cap-table data, this review uses what is reusable when it reads; there is no new scheduler ordering guarantee.
 
 ## 7. Slices
 
@@ -171,5 +173,5 @@ Rows marked "rule, no number" are switches rather than bands; they live in the s
 - Absent-clause recall is the known failure mode; the presence-boolean and `missing_terms` contract exists for this, and the fixture must plant absences.
 - The SECA term sheets are two-column PDFs; conversion splits clause names across lines. The per-fragment evidence check from PR #71 applies.
 - Question 2 is only as good as the cap-table snapshot; a stale or failed build must surface as such, never as a silent zero.
-- Bands need Enrico's and counsel's input and stay marked "to verify".
+- Rules and bands need domain review and remain inactive until approved; merging this document approves the architecture, not the proposed financial or legal judgments.
 - Nothing here replaces legal review. The report states that.

--- a/docs/cla-review-design.md
+++ b/docs/cla-review-design.md
@@ -1,0 +1,175 @@
+# CLA term sheet review — design
+
+Status: proposal for discussion (Enrico, Lucas and Manfred). Companion to issue #__. This document explains how the existing pieces work together and how the new skill sits on top of them. It is written to give an overview for readers over the whole toolkit. Scope: the term sheet of a convertible loan. A priced-round term sheet is a possible later extension on the same skeleton and is not covered here.
+
+## 1. The problem in one paragraph
+
+Before SICTIC members lend, they receive the term sheet of a convertible loan: two to six pages that fix the loan amount, interest, maturity, the conversion events with cap, discount and denominator, and the process terms. Usually it follows the SECA CLA model documentation, short or long form. The members' question is not "is this a well-drafted company document" but "is this instrument safe and fair for me as a lender, and what does it do in this particular company". Today the toolkit classifies such a document as `cla_term_sheet`, extracts its terms as part of a whole-data-room cap-table build, and judges them from the company's market-standard angle. Nothing looks at one term sheet, from the lender's side, in the context of this cap table, these existing loans and this SHA. The new skill `cla_review` does that.
+
+## 2. Two questions, not one
+
+**Question 1 — Are the terms themselves acceptable for a lender?** Judged against the two SECA CLA model term sheets (short form and long form, February 2025, with their drafting notes) and the Swiss Angel Investor Handbook, chapter 8.3 on convertible notes and 8.4 on the 10/20/100 non-bank rules. This question can be answered from the term sheet alone.
+
+**Question 2 — What do these terms do in this company, and to me?** Judged in context: the cap table (what my loan converts into at cap and at discount, and how the existing loans dilute me too), the outstanding CLAs (do my terms match or trail theirs, does an MFN clause exist anywhere, how many lenders does the company have and where do the non-bank rules land once N members join), and the SHA and articles (can the conversion actually be executed: consents, conditional capital or capital band, pre-emption waivers, what accession commits me to).
+
+Both questions end in the same report, and both start from the same extraction of the term sheet.
+
+## 3. What exists today, and what each part contributes
+
+```mermaid
+flowchart LR
+  subgraph dataroom[Startup data room]
+    docs[(parsed documents)]
+  end
+  subgraph cb[captable_build]
+    cls[classify every document<br/>incl. cla_term_sheet]
+    ext[extract each CLA via cla_terms.md<br/>quotes, missing_terms]
+    tab[extract cap table, register, pools]
+    ass[assess_cla: 12 items,<br/>company angle, bands in JSON]
+    agg[aggregate: lender groups,<br/>10/20 rule, term-sheet supersession]
+    con[consolidated JSON insight]
+    cls --> ext --> ass --> con
+    cls --> tab --> con
+    ext --> agg --> con
+  end
+  subgraph cr[captable report]
+    model[model.py: conversion at cap, discount, floor]
+    con --> model
+  end
+  subgraph sr[sha_review]
+    idf[model selects the document, path resolved]
+    ref[rank two SECA references]
+    aud[batch_audit over checklists]
+    syn[synthesis: 3 to 8 findings]
+    idf --> ref --> aud --> syn
+  end
+  docs --> cls
+  docs --> idf
+```
+
+**`captable_build` already extracts and assesses CLA term sheets.** Classification knows `cla_term_sheet` (draft, unsigned, or term sheet). Extraction is per document and driven by the team-editable checklist `config/captable_build/cla_terms.md`: 40 fields today, each with a verbatim quote, absent clauses forced into `missing_terms`. A term sheet gets status `term_sheet` and is kept out of the outstanding totals. `assess_cla` judges 12 items (discount, cap, interest, maturity, QEFR trigger, conversion capital, denominator, MFN, pro-rata, subordination, change of control, SHA accession) against bands in `assessment_rules.json`, from the company's "market standard" angle. Aggregation groups lenders on identical terms for the 10/20 non-bank rules and matches term sheets against executed loans. For the new skill this is the whole of "what does the term sheet say", already built.
+
+**`captable` already computes conversions.** `lib/captable/model.py` converts a note at cap, discount or floor under three round methods, with day-count interest accrual and stamp duty. For the new skill this is "what would I get", run for the member's own ticket instead of the company's loan stack.
+
+**`sha_review` supplies the review pattern.** Model-selected document, path resolved only for that candidate; two SECA references ranked; `lib.batch_audit` over checklists with the full document and the reference in the cacheable prefix; synthesis. For the new skill this is the lender-perspective judgment layer, with the two SECA CLA term sheets as references.
+
+**Shared foundations.** `InsightFile` owns every artifact: naming, manual precedence, freshness by source revision and configuration key. `generate_json` with a reviewer is the only way the model returns structured data.
+
+## 4. The new skill
+
+```mermaid
+flowchart TB
+  A[1 identify the term sheet<br/>one document, told apart from executed CLAs] --> B[2 extract terms<br/>cla_terms.md, extended with term-sheet fields]
+  B --> Q1
+  B --> Q2
+  subgraph Q1[Question 1 - the terms themselves]
+    C[3 assess, lender angle<br/>Python rules, bands in settings.json]
+    E[4 audit against the SECA CLA term sheets<br/>batch_audit, lender-perspective checklists]
+  end
+  subgraph Q2[Question 2 - the terms in this company]
+    D[5 my conversion on this cap table<br/>model.py, cap vs discount vs floor]
+    L[6 the existing loans<br/>terms compared, MFN, 10/20 before and after]
+    S[7 the SHA and articles<br/>can conversion be executed, what accession means]
+  end
+  C --> F[8 report<br/>tables + synthesis of 3 to 8 findings]
+  E --> F
+  D --> F
+  L --> F
+  S --> F
+```
+
+**1. Identify.** One term sheet is under review. Default: the model selects the most recent CLA term sheet in the data room with three retrieval queries, the code resolves that path only, and executed loans are excluded as candidates because they are context, not subject. Optional `--document` names the file directly, for the common case where the deal lead knows which draft the members are about to sign. Classification results from `captable_build`, when present, seed the candidates.
+
+**2. Extract.** `extract_cla` as it exists, over `cla_terms.md` extended with the fields a term sheet carries and a loan agreement does not: aggregate investment amount and range, lead investor and accession of further investors, reduction subject to existing shareholders' pre-emption rights, conversion share class, non-qualified-financing voluntary conversion, conditions precedent, representations and covenants (long form), list of binding provisions, documentation counsel. Adding fields is safe by design; the guarded fields stay untouched. Every value carries a verbatim quote, and absence is a recorded claim.
+
+### Question 1: the terms themselves
+
+**3. Assess, lender angle.** `assess_cla` runs as today and its 12 findings are kept. A second rule set in Python, thresholds in `config/cla_review/settings.json`, judges the same fields from the lender's side, encoding the SECA drafting notes and the handbook:
+
+| Term | What a lender wants (SECA notes, handbook 8.3) | Flagged |
+|---|---|---|
+| Valuation cap | present; the note calls it "often requested by investors" | absent with discount only, so the conversion price is unbounded |
+| Denominator | fully diluted is "more investor-friendly" per the SECA note | issued and outstanding, or unstated |
+| Discount | correlates with term; schedule that rises over time is fine | below band, or a high discount that also applies to a round closed within weeks |
+| Qualified-financing threshold | high enough to exclude tiny rounds, low enough to be reachable | missing, or set where insiders can trigger or avoid conversion; compare with the company's stated raise |
+| Maturity conversion | present with a stated price or fair-market mechanism; the SECA note says the cap is "rarely accepted" here | absent, so an unconverted loan at maturity is only a subordinated claim |
+| Interest | stated, with day count; safe-harbor cap noted where insiders lend | unstated, or above the safe-harbor rate with insiders lending |
+| Subordination | subordinated and unsecured, as the note expects; scope stated | non-subordinated is a legal-advice flag; scope unclear |
+| Change of control | mandatory conversion or repayment with a multiple | absent |
+| Lender majority and consents | who decides waivers and extensions | undefined |
+| Binding provisions | limited to confidentiality, costs, effect, law | economic terms declared binding, or exclusivity |
+| Documentation | SECA CLA short or long form referenced | bespoke or unnamed |
+
+The bands are marked "to verify" until confirmed (Enrico, Luc?), as `assessment_rules.json` does today.
+
+Proposed first set of lender-angle bands for `config/cla_review/settings.json`. Every value is a proposal to verify; sources are named where they exist, placeholders are marked as such.
+
+| Parameter | Proposed default | Source | Status |
+|---|---|---|---|
+| Discount, minimum a lender should expect | 15% | Handbook: 15 to 25% most common for angels; SECA band 5 to 30% | to verify |
+| Discount, schedule expected when term exceeds | 12 months | SECA note: discount correlates with term, rising schedule advised | placeholder |
+| Valuation cap | required | SECA note: often requested by investors; without it the price is unbounded | rule, no number |
+| Denominator | fully diluted | SECA note: fully diluted is the investor-friendly choice | rule, no number |
+| Qualified-financing threshold, minimum | 1x the aggregate loan amount | SECA note: not too low, or a tiny round converts the loans | placeholder |
+| Qualified-financing threshold, maximum | 3x the company's stated next-round target | SECA note: not too high, or the company can avoid conversion | placeholder |
+| Maturity conversion | mechanism and price required | SECA note: cap rarely accepted here, fixed valuation or fair market value used | rule, no number |
+| Term, maximum | 24 months | SECA note: bridge until the next round; number is a placeholder | placeholder |
+| Interest above safe harbor with insiders lending | ESTV rate of the year | SECA note and handbook 8.3; published yearly by the tax administration | needs the current figure, dated setting |
+| Change-of-control repayment multiple, minimum | 1x | SECA short form: conversion or repayment on change of control | placeholder |
+| Lender majority for waivers and extensions | defined, at least two thirds of principal | earlier cla_review sketch | placeholder |
+| Exclusivity | flagged when present | Handbook: not recommended for angel rounds | rule, no number |
+| Legal fees | each party bears its own | SECA short form wording | rule, no number |
+| Non-bank rules | 10 lenders on identical terms, 20 lenders in total | Handbook 8.4, fixed by law | fixed |
+| Member count N for the before-and-after | 5 | SICTIC syndicate practice; placeholder | placeholder |
+| Valuation range for the conversion table | 0.5x to 3x the cap | for the cap-versus-discount crossover | placeholder |
+
+Rows marked "rule, no number" are switches rather than bands; they live in the same file so they can be turned off. The non-bank thresholds are the only fixed values. The safe-harbor rate changes every year and belongs in a dated setting, not in code.
+
+**4. Audit against the SECA CLA term sheets.** sha_review pattern: rank the SECA short form and long form and run `lib.batch_audit` over checklists written from the lender's perspective, seeded from the earlier sketch: cap and discount interplay, maturity mechanism and price, conversion via consents versus conditional capital and who can block, QEFR realism, lender-majority definition, information rights, pro-rata and MFN, interest versus safe harbor, subordination scope, change-of-control multiple, stamp-duty position on conversion, syndicate or pooling vehicle, execution evidence. The audits cover what bands cannot: wording, consistency, and what the term sheet promises the definitive agreement will contain.
+
+### Question 2: the terms in this company
+
+**5. My conversion on this cap table.** From the consolidated `captable_build` insight and `model.py`, for the member's own ticket (an amount given on the command line, default the term sheet's minimum): shares and ownership on conversion at the cap, at the discount and at the floor for a range of next-round pre-money valuations, the price at which cap and discount cross, the effect of interest accrued to an assumed conversion date, ownership after the existing loans convert alongside, and stamp duty on conversion. If no snapshot exists the step yields an insufficient-evidence finding, not a failure.
+
+**6. The existing loans.** Every outstanding CLA in the insight is compared with the term sheet: cap, discount, denominator, maturity, interest, subordination side by side; whether an MFN clause in any existing loan pulls the term sheet's terms into it or vice versa; whether the term sheet would join an identical-terms group; and the SICTIC-specific number, the lender count and the largest identical-terms group with and without N members joining on these terms, against the 10 and 20 thresholds of the non-bank rules, reusing the aggregation code. Maturities are listed together so a cluster is visible.
+
+**7. The SHA and articles.** Whether the conversion can be executed as the term sheet assumes: conditional capital or a capital band on the register, or shareholder consents referenced, and whether those consents are documented; whether existing shareholders' pre-emption rights would reduce the members' allocation, as the SECA note warns; which share class the loan converts into and what rights that class has under the SHA; what SHA accession commits the lender to; whether the existing SHA restricts new loans or requires an investor consent for them. Without an SHA the review says so and treats accession terms as an open point.
+
+**8. Report.** Deterministic tables (terms with quotes, absent clauses, company-angle and lender-angle assessments, my conversion table, existing-loan comparison, 10/20 before and after, executability checklist) followed by a synthesis in the `sha_review` format: numbered findings with status, supporting checks, why it matters, recommended follow-up, closing with "not legal advice".
+
+**Artifacts.** JSON insights `identification`, `extraction`, `assessment`, `conversion`, `loan-context`, `sha-context`, `audits/<checklist>` under `insights/cla-review/`, and one Markdown report `cla-review-<startup>-<document>-<model>.md` directly under `insights/`, one per reviewed document. Manual files take precedence, `--fresh` discards generated work, failures are never reused.
+
+**Interfaces.** `cla_review(dataset_name, *, document=None, ticket=None, fresh=False) -> list[InsightFile]`; CLI `python -m skills.cla_review --startup <name> [--document <file>] [--ticket <amount>]`; harness `/cla_review <startup> [--document f] [--ticket n]`; registry `cla-review`, domain `startups`, soft dependency on `captable-build`.
+
+## 5. Reference material
+
+- SECA CLA Model Documentation, February 2025: term sheet short form and long form with drafting notes, to be converted to Markdown under `config/cla_review/reference_term_sheets/`, as the SHA references are. The long form adds conditions precedent, subscription mechanics, representations and covenants.
+- Swiss Angel Investor Handbook, chapter 8.3 (convertible notes: cap, discount, interest, day count, conversion mechanics) and 8.4 (the 10/20/100 non-bank rules), both already behind the cap-table skill; chapter 7 on the cap table for the dilution reading.
+- The repository's `docs/captable-design.md` ("Anatomy of a Swiss CLA") and `config/captable_build/cla_terms.md`, which is the extraction contract this skill extends.
+
+## 6. Decisions that touch existing contracts
+
+1. **Extend `cla_terms.md` rather than fork it.** The term-sheet-only fields are added to the shared checklist; `captable_build` extracts them too and ignores them. Alternative: a second checklist file for term sheets, which would duplicate 40 fields. Recommendation: extend.
+2. **Lender-angle rules next to `assess_cla`.** New module in `lib/captable/` (or `lib/cla_review/`), same finding shape, separate settings file. `assess_cla` is not changed.
+3. **Document-scoped entry point.** `--document` on a dataset-scoped skill is new. Alternative: always auto-identify. Recommendation: both, with `--document` optional. No entry point for a file outside the data room; the draft goes into the startup's `datasets/` folder and is synced, as every skill assumes.
+4. **Ticket amount as an input.** `--ticket` is a user input that shapes the output; it goes into the configuration key so a different ticket produces a different insight. Recommendation: accept it, default to the term sheet's minimum or the aggregate amount divided by the expected member count from settings.
+5. **Audit status scale.** Keep `unclear | too weak | balanced | too strong` from `sha_review`, read from the lender's side in the checklist wording.
+6. **Dependency.** Soft on `captable-build`. Question 1 works without a snapshot; question 2 then reports insufficient evidence.
+
+## 7. Slices
+
+| Slice | Content | Model calls |
+|---|---|---|
+| 0 | This document upstream, both SECA CLA term sheets as Markdown references, the synthetic fixture extended with a Fixture Robotics AG CLA term sheet and `ground_truth.json` with planted absences, skill package with SKILL.md and all contract-test registrations, README row | none |
+| 1 | Identify, extract with the extended checklist, lender-angle assessment, report (question 1 without audits) | yes |
+| 2 | My conversion, existing-loan comparison, 10/20 before and after (question 2, deterministic part) | none |
+| 3 | SHA and articles executability, reference ranking, lender-perspective checklists (Enrico), synthesis | yes |
+| 4 | Recall eval on a filled SECA term sheet with deleted clauses, MCP tool, deep-dive links | yes |
+
+## 8. Risks and known limits
+
+- Absent-clause recall is the known failure mode; the presence-boolean and `missing_terms` contract exists for this, and the fixture must plant absences.
+- The SECA term sheets are two-column PDFs; conversion splits clause names across lines. The per-fragment evidence check from PR #71 applies.
+- Question 2 is only as good as the cap-table snapshot; a stale or failed build must surface as such, never as a silent zero.
+- Bands need Enrico's and counsel's input and stay marked "to verify".
+- Nothing here replaces legal review. The report states that.


### PR DESCRIPTION
## Summary

Documentation only. Adds `docs/cla-review-design.md`, the proposal for a new skill `cla_review` that reviews one convertible-loan term sheet from the lender's perspective: the terms themselves against the SECA CLA model term sheets and the Swiss Angel Investor Handbook, and the terms in the context of this cap table, the outstanding loans and the SHA. It explains how `captable_build`, `captable` and `sha_review` contribute and where new code is needed.

The decisions that touch existing contracts are collected in the companion issue (#73). Please review the document here line by line; the bands and checklist content are marked as proposals to verify.

## Compatibility

No code, configuration or test changes.

## Validation

`git diff --check` clean; the documentation link test only covers the maintained docs list, which this file is not yet part of.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PhBQYMK2YCoPRyA22LQQdH